### PR TITLE
ability to disable the progress notification in the status bar

### DIFF
--- a/dfu/src/main/java/no/nordicsemi/android/dfu/DfuServiceInitiator.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/DfuServiceInitiator.java
@@ -38,6 +38,8 @@ public class DfuServiceInitiator {
 	private final String deviceAddress;
 	private String deviceName;
 
+	private boolean disableNotification;
+
 	private Uri fileUri;
 	private String filePath;
 	private int fileResId;
@@ -68,6 +70,17 @@ public class DfuServiceInitiator {
 	 */
 	public DfuServiceInitiator setDeviceName(final String name) {
 		this.deviceName = name;
+		return this;
+	}
+
+	/**
+	 * Sets whether the progress notification in the status bar should be disabled.
+	 * Defaults to false.
+	 * @param disableNotification whether to disable the notification
+	 * @return the builder
+	 */
+	public DfuServiceInitiator setDisableNotification(final boolean disableNotification) {
+		this.disableNotification = disableNotification;
 		return this;
 	}
 
@@ -245,6 +258,7 @@ public class DfuServiceInitiator {
 
 		intent.putExtra(DfuBaseService.EXTRA_DEVICE_ADDRESS, deviceAddress);
 		intent.putExtra(DfuBaseService.EXTRA_DEVICE_NAME, deviceName);
+		intent.putExtra(DfuBaseService.EXTRA_DISABLE_NOTIFICATION, disableNotification);
 		intent.putExtra(DfuBaseService.EXTRA_FILE_MIME_TYPE, mimeType);
 		intent.putExtra(DfuBaseService.EXTRA_FILE_TYPE, fileType);
 		intent.putExtra(DfuBaseService.EXTRA_FILE_URI, fileUri);


### PR DESCRIPTION
This is useful for apps that don't want to put anything in the status bar, and/or don't want to expose the ability for the user to abort the update.

It should have no effect on existing code, since the default behavior remains the same. The only change for existing code is that I moved the calls to `sendProgressBroadcast` / `sendErrorBroadcast` further up in the `updateProgressNotification` method for easier control flow. As far as I can tell this should have no effect, but I wanted to point it out just in case.