### PR TITLE
Bugfix: Unexpected disconnect after enabling CCCD

### DIFF
--- a/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -2260,6 +2260,10 @@ public abstract class DfuBaseService extends IntentService {
 				while ((((type == NOTIFICATIONS && !mNotificationsEnabled) || (type == INDICATIONS && !mServiceChangedIndicationsEnabled))
 						&& mConnectionState == STATE_CONNECTED_AND_READY && mError == 0 && !mAborted) || mPaused)
 					mLock.wait();
+
+				// To prevent BLE device to disconnect with status 133 or 14 or 8, we need to sleep a bit more.
+				// Remove wait, to reproduce this issue on HTC M9, running Android 5.1.1.
+				mLock.wait(1000);
 			}
 		} catch (final InterruptedException e) {
 			loge("Sleeping interrupted", e);


### PR DESCRIPTION
This doesn't look as a bug in library. So this is a small hack that
works for some Android devices, but doesn't harm dfu process on other
devices at all.

E.g. without this hack, dfu process can't finish successfully on HTC M9,
running Android 5.1.1. It disconnets two operations (calling two writeOpCode
methods) after enabling CCCD, with one of this statuses: 133, 14 or 8.