### PR TITLE
Add retries on 133 errors

### DIFF
--- a/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -1031,8 +1031,8 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 					logi("Restarting the service");
 					final Intent newIntent = new Intent();
 					newIntent.fillIn(intent, Intent.FILL_IN_COMPONENT | Intent.FILL_IN_PACKAGE);
-                    int attempts = intent.getIntExtra(EXTRA_ATTEMPT,0);
-                    attempts++;
+					int attempts = intent.getIntExtra(EXTRA_ATTEMPT,0);
+					attempts++;
 					newIntent.putExtra(EXTRA_ATTEMPT, attempts);
 					startService(newIntent);
 					return;

--- a/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -978,8 +978,8 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 			if (mConnectionState == STATE_DISCONNECTED) {
 
 				loge("Device got disconnected before service discovery finished");
-                // Connection usually fails due to a 133 error (device unreachable, or.. something else went wrong).
-                // Usually trying the same for the second or third time works.
+				// Connection usually fails due to a 133 error (device unreachable, or.. something else went wrong).
+				// Usually trying the same for the second or third time works.
 				if (intent.getIntExtra(EXTRA_ATTEMPT, 0) < 2) {
 					sendLogBroadcast(LOG_LEVEL_WARNING, "Retrying...");
 


### PR DESCRIPTION
I've seen a lot of 133 errors where the connectionState gets set to STATE_DISCONNECTED before the discovery is complete. By adding your reconnection logic to this case as well I've been able to almost remove the problem.

I've also increased the number of connection attempts from 2 to 3. This should actually be a configurable number, so the Intent EXTRA_ATTEMPT could be changes to EXTRA_NUM_ATTEMPTS and the service could decrement this number. But this works for now and makes the DFU library more stable.