### PR TITLE
Mark position after execute for CRC retries

### DIFF
--- a/dfu/src/main/java/no/nordicsemi/android/dfu/SecureDfuImpl.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/SecureDfuImpl.java
@@ -514,13 +514,16 @@ import no.nordicsemi.android.error.SecureDfuError;
 					// Increment iterator
 					currentChunk++;
 					attempt = 1;
+					mFirmwareStream.mark(0);
 				} else {
 					if (attempt < MAX_ATTEMPTS) {
 						attempt++;
-						logi("CRC does not match! Retrying...(" + attempt + "/" + MAX_ATTEMPTS + ")");
+						logi(String.format(Locale.US,"CRC does not match! Expected %08X Retrying...(%d/%d)",crc,attempt,MAX_ATTEMPTS));
 						mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_WARNING, "CRC does not match! Retrying...(" + attempt + "/" + MAX_ATTEMPTS + ")");
 						try {
 							mFirmwareStream.reset();
+							final int crcAfterReset = (int) (((ArchiveInputStream) mFirmwareStream).getCrc32() & 0xFFFFFFFFL);
+							logi(String.format(Locale.US,"CRC after reset is %08X",crcAfterReset));
 							mProgressInfo.setBytesSent(checksum.offset - info.maxSize);
 						} catch (final IOException e) {
 							loge("Error while resetting the firmware stream", e);
@@ -528,7 +531,7 @@ import no.nordicsemi.android.error.SecureDfuError;
 							return;
 						}
 					} else {
-						loge("CRC does not match!");
+						loge(String.format("CRC does not match! Expected %08X",crc));
 						mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_ERROR, "CRC does not match!");
 						mService.terminateConnection(gatt, DfuBaseService.ERROR_CRC_ERROR);
 						return;

--- a/dfu/src/main/java/no/nordicsemi/android/dfu/SecureDfuImpl.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/SecureDfuImpl.java
@@ -514,16 +514,18 @@ import no.nordicsemi.android.error.SecureDfuError;
 					// Increment iterator
 					currentChunk++;
 					attempt = 1;
+					//Mark this location after completion of successful transfer.  In the event of a CRC retry on the next packet we will restart from this point.
 					mFirmwareStream.mark(0);
 				} else {
+					String crcFailMessage = String.format(Locale.US, "CRC does not match! Expected %08X but found %08X.", crc, checksum.CRC32);
 					if (attempt < MAX_ATTEMPTS) {
 						attempt++;
-						logi(String.format(Locale.US,"CRC does not match! Expected %08X Retrying...(%d/%d)",crc,attempt,MAX_ATTEMPTS));
-						mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_WARNING, "CRC does not match! Retrying...(" + attempt + "/" + MAX_ATTEMPTS + ")");
+						crcFailMessage += String.format(Locale.US, " Retrying...(%d/%d)", attempt, MAX_ATTEMPTS);
+						logi(crcFailMessage);
+						mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_WARNING, crcFailMessage);
 						try {
+							// Reset the CRC and file pointer back to the previous mark() point after completion of the last successful packet.
 							mFirmwareStream.reset();
-							final int crcAfterReset = (int) (((ArchiveInputStream) mFirmwareStream).getCrc32() & 0xFFFFFFFFL);
-							logi(String.format(Locale.US,"CRC after reset is %08X",crcAfterReset));
 							mProgressInfo.setBytesSent(checksum.offset - info.maxSize);
 						} catch (final IOException e) {
 							loge("Error while resetting the firmware stream", e);
@@ -531,8 +533,8 @@ import no.nordicsemi.android.error.SecureDfuError;
 							return;
 						}
 					} else {
-						loge(String.format("CRC does not match! Expected %08X",crc));
-						mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_ERROR, "CRC does not match!");
+						loge(crcFailMessage);
+						mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_ERROR, crcFailMessage);
 						mService.terminateConnection(gatt, DfuBaseService.ERROR_CRC_ERROR);
 						return;
 					}


### PR DESCRIPTION
I've noticed when using in a noisy environment (or if I drop my phone in a Faraday Cage)
 if I ever see a CRC error on a data packet all of the subsequent retries fail and the download fails.

I noticed if I print the CRC values expected they change on each retry
attempt.  This seems wrong, since I believe the intent is just to re-send
the last chunk?

I suspect there's a mark() call missing in the success transfer case,
and the position of the last successful create->execute transfer should
be saved. The next retry transfer should reset to the mark position after the last
successful transfer.

If I add a call to mFirwmareStream.mark() in the CRC success case after
writeExecute() completes I am able to successfully recover from CRC errors with my setup.

Is this a correct change?  Or am I missing something about how CRC retries are intended to work?
