### PR TITLE
Added a custom scanner

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+//        classpath 'com.android.tools.build:gradle:2.3.3'
         /*
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3"
         // The following dependency has been replaced with newer version according to https://github.com/dcendents/android-maven-plugin

--- a/dfu/build.gradle
+++ b/dfu/build.gradle
@@ -41,7 +41,7 @@ ext {
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    buildToolsVersion '26.0.1'
 
     defaultConfig {
         minSdkVersion 18
@@ -59,7 +59,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:support-v4:25.4.0'
+    compile 'com.android.support:support-v4:25.3.1'
     compile 'com.google.code.gson:gson:2.7'
 }
 /*

--- a/dfu/src/main/java/no/nordicsemi/android/dfu/BaseDfuImpl.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/BaseDfuImpl.java
@@ -655,7 +655,7 @@ import no.nordicsemi.android.dfu.internal.scanner.BootloaderScannerFactory;
 		String newAddress = null;
 		if (scanForBootloader) {
 			mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_VERBOSE, "Scanning for the DFU Bootloader...");
-			newAddress = BootloaderScannerFactory.getScanner().searchFor(mGatt.getDevice().getAddress());
+			newAddress = BootloaderScannerFactory.getScanner(mService.getBootloaderReferee(mGatt)).searchFor(mGatt.getDevice().getAddress(), mGatt.getDevice().getName());
 			logi("Scanning for new address finished with: " + newAddress);
 			if (newAddress != null)
 				mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_INFO, "DFU Bootloader found with address " + newAddress);

--- a/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -63,6 +63,7 @@ import no.nordicsemi.android.dfu.internal.exception.DeviceDisconnectedException;
 import no.nordicsemi.android.dfu.internal.exception.DfuException;
 import no.nordicsemi.android.dfu.internal.exception.SizeValidationException;
 import no.nordicsemi.android.dfu.internal.exception.UploadAbortedException;
+import no.nordicsemi.android.dfu.internal.scanner.BootloaderCustomScanner;
 import no.nordicsemi.android.error.GattError;
 
 /**
@@ -1622,5 +1623,9 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 	private void logi(final String message) {
 		if (DfuBaseService.DEBUG)
 			Log.i(TAG, message);
+	}
+
+	public BootloaderCustomScanner.BootloaderReferee getBootloaderReferee(BluetoothGatt gatt) {
+		return null;
 	}
 }

--- a/dfu/src/main/java/no/nordicsemi/android/dfu/internal/scanner/BootloaderScanner.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/internal/scanner/BootloaderScanner.java
@@ -50,5 +50,5 @@ public interface BootloaderScanner {
 	 *            the application device address
 	 * @return the address of the advertising DFU bootloader. If may be the same as the application address or one with the last byte incremented by 1 (AA:BB:CC:DD:EE:45/FF -&gt; AA:BB:CC:DD:EE:46/00).
 	 */
-	String searchFor(final String deviceAddress);
+	String searchFor(final String deviceAddress, final String name);
 }

--- a/dfu/src/main/java/no/nordicsemi/android/dfu/internal/scanner/BootloaderScannerFactory.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/internal/scanner/BootloaderScannerFactory.java
@@ -39,4 +39,15 @@ public class BootloaderScannerFactory {
 			return new BootloaderScannerLollipop();
 		return new BootloaderScannerJB();
 	}
+
+	/**
+	 * Returns the custom scanner implementation.
+	 *
+	 * @return the bootloader scanner
+	 * @param bootloaderReferee Callback to judge the scaned device is or not the expected one;
+	 */
+	public static BootloaderScanner getScanner(BootloaderCustomScanner.BootloaderReferee bootloaderReferee) {
+		if (bootloaderReferee == null) return getScanner();
+		return new BootloaderCustomScanner(bootloaderReferee);
+	}
 }

--- a/dfu/src/main/java/no/nordicsemi/android/dfu/internal/scanner/BootloaderScannerLollipop.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/internal/scanner/BootloaderScannerLollipop.java
@@ -42,7 +42,7 @@ public class BootloaderScannerLollipop extends ScanCallback implements Bootloade
 	private boolean mFound;
 
 	@Override
-	public String searchFor(final String deviceAddress) {
+	public String searchFor(final String deviceAddress, final String deviceName) {
 		final String firstBytes = deviceAddress.substring(0, 15);
 		final String lastByte = deviceAddress.substring(15); // assuming that the device address is correct
 		final String lastByteIncremented = String.format("%02X", (Integer.valueOf(lastByte, 16) + ADDRESS_DIFF) & 0xFF);


### PR DESCRIPTION
There is one situation for me:
The mac addresses[**MAC_1**](by `BluttoothDevece.getAddress()`) of of the devices are "made" by programmatically for some reason,
After one device reboot to bootloader will cus the mac address(by `BluttoothDevece.getAddress()`) neither the original [**MAC_1**] nor "original address" +1. 
I add a class and a Interface to make it's possible let the `BaseService` to judge the scanned
device is or not the expect one.
Just override
`DfuBaseService#getBootloaderReferee(BluetoothGatt gatt)`
and return a `BootloaderReferee` to get it.