### PR TITLE
Fix lingering "Disconnecting" notification

### DIFF
--- a/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -1396,8 +1396,9 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 			return;
 
 		// the notification may not be refreshed too quickly as the ABORT button becomes not clickable
+		// If new state is an end-state, update regardless so it will not stick around in "Disconnecting" state
 		final long now = SystemClock.elapsedRealtime();
-		if (now - mLastNotificationTime < 250)
+		if (now - mLastNotificationTime < 250 && !(PROGRESS_COMPLETED == progress || PROGRESS_ABORTED == progress))
 			return;
 		mLastNotificationTime = now;
 


### PR DESCRIPTION
- Notifications weren't being updated if they came within 250ms of the previous update, regardless of end-state being reached
- Added check that if the progress was at an end-state, upate anyway
- Tested with real device update and upping delay checked to ensure skipping some non-end-cases

Issue #67 