### PR TITLE
fix upload not aborted on service destroy

### DIFF
--- a/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -890,6 +890,9 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 	public void onDestroy() {
 		super.onDestroy();
 
+		if (mDfuServiceImpl != null)
+			mDfuServiceImpl.abort();
+
 		final LocalBroadcastManager manager = LocalBroadcastManager.getInstance(this);
 		manager.unregisterReceiver(mDfuActionReceiver);
 


### PR DESCRIPTION
fixes #97 , #108  
When the app is killed by user and the service with it, it closes the file stream, but doesn't abort the DFU process, which then tries to read next chunk to send to the device and crashes.

Not sure if this is the best way to fix it, but at least it doesn't crash anymore.