### PR TITLE
Bugfix/131

### DIFF
--- a/dfu/src/main/java/no/nordicsemi/android/dfu/BaseDfuImpl.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/BaseDfuImpl.java
@@ -289,12 +289,14 @@ import no.nordicsemi.android.dfu.internal.scanner.BootloaderScannerFactory;
 
 		int size;
 		try {
+			initPacketStream.reset();
 			size = initPacketStream.available();
 		} catch (final Exception e) {
 			size = 0;
 		}
 		mInitPacketSizeInBytes = size;
 		try {
+			firmwareStream.reset();
 			size = firmwareStream.available();
 		} catch (final Exception e) {
 			size = 0;

--- a/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -1052,6 +1052,11 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 							initIs = new ByteArrayInputStream(zhis.getSystemInit());
 					}
 				}
+
+				// The input streams will be reset in initialize(), keep
+				is.mark(is.available());
+				initIs.mark(initIs.available());
+
 				mFirmwareInputStream = is;
 				mInitFileInputStream = initIs;
 				sendLogBroadcast(LOG_LEVEL_INFO, "Firmware file opened successfully");

--- a/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -1058,9 +1058,14 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 					}
 				}
 
-				// The input streams will be reset in initialize(), keep
-				is.mark(is.available());
-				initIs.mark(initIs.available());
+				// Mark the beginning of the streams. In case the service is restarted, it should
+				// re-upload again the whole file.
+				if (firstRun) {
+					// The input streams will be reset in initialize(), keep
+					is.mark(is.available());
+					if (initIs != null)
+						initIs.mark(initIs.available());
+				}
 
 				mFirmwareInputStream = is;
 				mInitFileInputStream = initIs;

--- a/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyDfuImpl.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyDfuImpl.java
@@ -260,13 +260,6 @@ import no.nordicsemi.android.error.LegacyDfuError;
 				appImageSize = zhis.applicationImageSize();
 			}
 
-			// If there is no DFU Version characteristic (SDK 6.1 or older), 1 second delay is required (600 ms was not enough).
-			// See: https://github.com/NordicSemiconductor/Android-DFU-Library/issues/131
-			// and: https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library/blob/88b2a836bc627fcadd2528c8da4ce630309118d9/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift#L235
-			if (version == 0) {
-				mService.waitFor(1000);
-			}
-
 			boolean extendedInitPacketSupported = true;
 			try {
 				OP_CODE_START_DFU[1] = (byte) fileType;
@@ -451,6 +444,13 @@ import no.nordicsemi.android.error.LegacyDfuError;
 				mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_APPLICATION, "Response received (Op Code = " + response[1] + ", Status = " + status + ")");
 				if (status != DFU_STATUS_SUCCESS)
 					throw new RemoteDfuException("Device returned error after sending init packet", status);
+			}
+
+			// If there is no DFU Version characteristic (SDK 6.1 or older), 1 second delay is required (600 ms was not enough).
+			// See: https://github.com/NordicSemiconductor/Android-DFU-Library/issues/131
+			// and: https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library/blob/88b2a836bc627fcadd2528c8da4ce630309118d9/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift#L235
+			if (version == 0) {
+				mService.waitFor(1000);
 			}
 
 			// Send the number of packets of firmware before receiving a receipt notification

--- a/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyDfuImpl.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyDfuImpl.java
@@ -260,6 +260,13 @@ import no.nordicsemi.android.error.LegacyDfuError;
 				appImageSize = zhis.applicationImageSize();
 			}
 
+			// If there is no DFU Version characteristic (SDK 6.1 or older), 1 second delay is required (600 ms was not enough).
+			// See: https://github.com/NordicSemiconductor/Android-DFU-Library/issues/131
+			// and: https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library/blob/88b2a836bc627fcadd2528c8da4ce630309118d9/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift#L235
+			if (version == 0) {
+				mService.waitFor(1000);
+			}
+
 			boolean extendedInitPacketSupported = true;
 			try {
 				OP_CODE_START_DFU[1] = (byte) fileType;

--- a/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyDfuImpl.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyDfuImpl.java
@@ -64,6 +64,7 @@ import no.nordicsemi.android.error.LegacyDfuError;
 	private static final int OP_CODE_RESPONSE_CODE_KEY = 0x10; // 16
 	private static final int OP_CODE_PACKET_RECEIPT_NOTIF_KEY = 0x11; // 11
 	private static final byte[] OP_CODE_START_DFU = new byte[]{OP_CODE_START_DFU_KEY, 0x00};
+	private static final byte[] OP_CODE_START_DFU_V1 = new byte[]{OP_CODE_START_DFU_KEY};
 	private static final byte[] OP_CODE_INIT_DFU_PARAMS = new byte[]{OP_CODE_INIT_DFU_PARAMS_KEY}; // SDK 6.0.0 or older
 	private static final byte[] OP_CODE_INIT_DFU_PARAMS_START = new byte[]{OP_CODE_INIT_DFU_PARAMS_KEY, 0x00};
 	private static final byte[] OP_CODE_INIT_DFU_PARAMS_COMPLETE = new byte[]{OP_CODE_INIT_DFU_PARAMS_KEY, 0x01};
@@ -366,7 +367,7 @@ import no.nordicsemi.android.error.LegacyDfuError;
 						// Send Start DFU command to Control Point
 						mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_VERBOSE, "Switching to DFU v.1");
 						logi("Resending Start DFU command (Op Code = 1)");
-						writeOpCode(mControlPointCharacteristic, OP_CODE_START_DFU); // If has 2 bytes, but the second one is ignored
+						writeOpCode(mControlPointCharacteristic, OP_CODE_START_DFU_V1);
 						mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_APPLICATION, "DFU Start sent (Op Code = 1)");
 
 						// Send image size in bytes to DFU Packet

--- a/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyDfuImpl.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyDfuImpl.java
@@ -452,6 +452,7 @@ import no.nordicsemi.android.error.LegacyDfuError;
 			//       It has been tested that PRN = 10 may be the highest supported value.
 			final int numberOfPacketsBeforeNotification = extendedInitPacketSupported || (mPacketsBeforeNotification > 0 && mPacketsBeforeNotification <= 10) ? mPacketsBeforeNotification : 10;
 			if (numberOfPacketsBeforeNotification > 0) {
+				mPacketsBeforeNotification = numberOfPacketsBeforeNotification;
 				logi("Sending the number of packets before notifications (Op Code = 8, Value = " + numberOfPacketsBeforeNotification + ")");
 				setNumberOfPackets(OP_CODE_PACKET_RECEIPT_NOTIF_REQ, numberOfPacketsBeforeNotification);
 				writeOpCode(mControlPointCharacteristic, OP_CODE_PACKET_RECEIPT_NOTIF_REQ);

--- a/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyDfuImpl.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyDfuImpl.java
@@ -446,13 +446,6 @@ import no.nordicsemi.android.error.LegacyDfuError;
 					throw new RemoteDfuException("Device returned error after sending init packet", status);
 			}
 
-			// If there is no DFU Version characteristic (SDK 6.1 or older), 1 second delay is required (600 ms was not enough).
-			// See: https://github.com/NordicSemiconductor/Android-DFU-Library/issues/131
-			// and: https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library/blob/88b2a836bc627fcadd2528c8da4ce630309118d9/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift#L235
-			if (version == 0) {
-				mService.waitFor(1000);
-			}
-
 			// Send the number of packets of firmware before receiving a receipt notification
 			// Note: DFU bootloaders from SDK 6.0.0 or older were unable to save incoming data to the flash memory with the same speed
 			//       as they are being sent from modern devices, therefore the PRNs are here force-enabled for them.


### PR DESCRIPTION
This PR fixes the #131 issue, where:
1. Firmware Input Stream wasn't reset properly
2. 0x01-04 was sent instead of 0x01, in very old Legacy DFU (actually, the 2nd byte was ignored, but it shoudln't be sent at all)
3. The target was sending error 6 just after receiving first packets. Old DFU requires 1 second delay before the firmware is sent. Some more info regarding this in iOS library: https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library/blob/master/iOSDFULibrary/Classes/Implementation/LegacyDFU/Services/LegacyDFUService.swift#L235.