### PR TITLE
Added an option to set custom ble notification characteristics and added ble notification events

### DIFF
--- a/dfu/src/main/java/no/nordicsemi/android/dfu/BaseDfuImpl.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/BaseDfuImpl.java
@@ -49,8 +49,8 @@ import no.nordicsemi.android.dfu.internal.scanner.BootloaderScannerFactory;
 	protected static final UUID GENERIC_ATTRIBUTE_SERVICE_UUID = new UUID(0x0000180100001000L, 0x800000805F9B34FBL);
 	protected static final UUID SERVICE_CHANGED_UUID = new UUID(0x00002A0500001000L, 0x800000805F9B34FBL);
 	protected static final UUID CLIENT_CHARACTERISTIC_CONFIG = new UUID(0x0000290200001000L, 0x800000805f9b34fbL);
-	protected static final int NOTIFICATIONS = 1;
-	protected static final int INDICATIONS = 2;
+	public static final int NOTIFICATIONS = 1;
+	public static final int INDICATIONS = 2;
 
 	protected static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
 	protected static final int MAX_PACKET_SIZE_DEFAULT = 20; // the default maximum number of bytes in one packet is 20.
@@ -370,7 +370,7 @@ import no.nordicsemi.android.dfu.internal.scanner.BootloaderScannerFactory;
 	 * @throws DfuException
 	 * @throws UploadAbortedException
 	 */
-	protected void enableCCCD(final BluetoothGattCharacteristic characteristic, final int type) throws DeviceDisconnectedException, DfuException, UploadAbortedException {
+	public void enableCCCD(final BluetoothGattCharacteristic characteristic, final int type) throws DeviceDisconnectedException, DfuException, UploadAbortedException {
 		final BluetoothGatt gatt = mGatt;
 		final String debugString = type == NOTIFICATIONS ? "notifications" : "indications";
 		if (!mConnected)

--- a/dfu/src/main/java/no/nordicsemi/android/dfu/DfuNotificationListener.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/DfuNotificationListener.java
@@ -1,0 +1,17 @@
+package no.nordicsemi.android.dfu;
+
+import java.util.UUID;
+
+/**
+ * Listener for characteristic notification events. This listener should be used instead of creating the BroadcastReceiver on your own.
+ */
+public interface DfuNotificationListener {
+
+    /**
+     * Method called when a notification was received from the DFU device.
+     * @param deviceAddress the target device address
+     * @param characteristicUuid the characteristic uuid of the notifying characteristic
+     * @param data  the notified data
+     */
+    void onNotificationEvent(final String deviceAddress, final UUID characteristicUuid, final byte[] data);
+}

--- a/dfu/src/main/java/no/nordicsemi/android/dfu/DfuService.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/DfuService.java
@@ -23,6 +23,7 @@
 package no.nordicsemi.android.dfu;
 
 import android.bluetooth.BluetoothGatt;
+import android.bluetooth.BluetoothGattCharacteristic;
 import android.content.Intent;
 
 import java.io.InputStream;
@@ -41,6 +42,9 @@ import no.nordicsemi.android.dfu.internal.exception.UploadAbortedException;
 	 * @return true if initialization was successful and the DFU process may begin, false to finish teh DFU service
 	 */
 	boolean initialize(final Intent intent, final BluetoothGatt gatt, final int fileType, final InputStream firmwareStream, final InputStream initPacketStream) throws DfuException, DeviceDisconnectedException, UploadAbortedException;
+
+
+	void enableCCCD(final BluetoothGattCharacteristic characteristic, final int type) throws DeviceDisconnectedException, DfuException, UploadAbortedException;
 
 	/** Performs the DFU process. */
 	void performDfu(final Intent intent) throws DfuException, DeviceDisconnectedException, UploadAbortedException;

--- a/dfu/src/main/java/no/nordicsemi/android/dfu/DfuServiceInitiator.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/DfuServiceInitiator.java
@@ -88,6 +88,7 @@ public class DfuServiceInitiator {
 	private Parcelable[] experimentalButtonlessDfuUuids;
 	private Parcelable[] buttonlessDfuWithoutBondSharingUuids;
 	private Parcelable[] buttonlessDfuWithBondSharingUuids;
+	private ParcelUuid[] customNotificationUUIDs;
 
 	/**
 	 * Creates the builder. Use setZip(...), or setBinOrHex(...) methods to specify the file you
@@ -491,6 +492,14 @@ public class DfuServiceInitiator {
 		return this;
 	}
 
+	public DfuServiceInitiator setCustomNotificationUUIDs(final UUID[] customNotificationUUIDs) {
+		this.customNotificationUUIDs = new ParcelUuid[customNotificationUUIDs.length];
+		for (int i=0; i < customNotificationUUIDs.length; i++) {
+			this.customNotificationUUIDs[i] = new ParcelUuid(customNotificationUUIDs[i]);
+		}
+		return this;
+	}
+
 	/**
 	 * Sets the URI to the Distribution packet (ZIP) or to a ZIP file matching the deprecated naming
 	 * convention.
@@ -719,6 +728,8 @@ public class DfuServiceInitiator {
 			intent.putExtra(DfuBaseService.EXTRA_CUSTOM_UUIDS_FOR_BUTTONLESS_DFU_WITHOUT_BOND_SHARING, buttonlessDfuWithoutBondSharingUuids);
 		if (buttonlessDfuWithBondSharingUuids != null)
 			intent.putExtra(DfuBaseService.EXTRA_CUSTOM_UUIDS_FOR_BUTTONLESS_DFU_WITH_BOND_SHARING, buttonlessDfuWithBondSharingUuids);
+		if (customNotificationUUIDs != null)
+			intent.putExtra(DfuBaseService.EXTRA_CUSTOM_UUIDS_FOR_NOTIFICATIONS, customNotificationUUIDs);
 
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && startAsForegroundService) {
 			// On Android Oreo and above the service must be started as a foreground service to make it accessible from

--- a/dfu/src/main/java/no/nordicsemi/android/dfu/SecureDfuImpl.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/SecureDfuImpl.java
@@ -86,6 +86,11 @@ class SecureDfuImpl extends BaseCustomDfuImpl {
 
 		@Override
 		public void onCharacteristicChanged(final BluetoothGatt gatt, final BluetoothGattCharacteristic characteristic) {
+			if (characteristic.getUuid().toString().equalsIgnoreCase(DFU_CONTROL_POINT_UUID.toString()) == false &&
+					characteristic.getUuid().toString().equalsIgnoreCase(DFU_PACKET_UUID.toString()) == false) {
+				return;	// not interested
+			}
+
 			if (characteristic.getValue() == null || characteristic.getValue().length < 3) {
 				loge("Empty response: " + parse(characteristic));
 				mError = DfuBaseService.ERROR_INVALID_RESPONSE;


### PR DESCRIPTION
We had extended the basic Nordic bootloader with some extra functionality, which we need to get reported to the layers controlling the DFU Library. I have added an option to add custom characteristic IDs to subscribe to, and implemented BLE notification events, which are reported to the controlling layer(s).