### PR TITLE
Added function that can be specified by assete file name in setZip

### DIFF
--- a/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -254,6 +254,11 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 	 * See {@link #EXTRA_FILE_PATH} for details.
 	 */
 	public static final String EXTRA_FILE_RES_ID = "no.nordicsemi.android.dfu.extra.EXTRA_FILE_RES_ID";
+
+	/**
+	 * See {@link #EXTRA_FILE_PATH} for details.
+	 */
+	public static final String EXTRA_ASSETE_FILE_NAME = "no.nordicsemi.android.dfu.extra.EXTRA_ASSETE_FILE_NAME";
 	/**
 	 * The Init packet URI. This file is required if the Extended Init Packet is required (SDK 7.0+). Must point to a 'dat' file corresponding with the selected firmware.
 	 * The Init packet may contain just the CRC (in case of older versions of DFU) or the Extended Init Packet in binary format (SDK 7.0+).
@@ -960,6 +965,7 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 		final boolean disableNotification = intent.getBooleanExtra(EXTRA_DISABLE_NOTIFICATION, false);
 		final boolean foregroundService = intent.getBooleanExtra(EXTRA_FOREGROUND_SERVICE, true);
 		final String filePath = intent.getStringExtra(EXTRA_FILE_PATH);
+		final String asseteFileName = intent.getStringExtra(EXTRA_ASSETE_FILE_NAME);
 		final Uri fileUri = intent.getParcelableExtra(EXTRA_FILE_URI);
 		final int fileResId = intent.getIntExtra(EXTRA_FILE_RES_ID, 0);
 		final String initFilePath = intent.getStringExtra(EXTRA_INIT_FILE_PATH);
@@ -1042,6 +1048,8 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 						is = openInputStream(filePath, mimeType, mbrSize, fileType);
 					} else if (fileResId > 0) {
 						is = openInputStream(fileResId, mimeType, mbrSize, fileType);
+					} else if (asseteFileName != null){
+						is = getApplicationContext().getAssets().open(asseteFileName);
 					}
 
 					// The Init file Input Stream is kept global only in case it was provided

--- a/dfu/src/main/java/no/nordicsemi/android/dfu/DfuServiceInitiator.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/DfuServiceInitiator.java
@@ -62,6 +62,7 @@ public class DfuServiceInitiator {
 
 	private Uri fileUri;
 	private String filePath;
+	private String fileAsseteName;
 	private int fileResId;
 
 	private Uri initFileUri;
@@ -517,6 +518,13 @@ public class DfuServiceInitiator {
 		return init(null, path, 0, DfuBaseService.TYPE_AUTO, DfuBaseService.MIME_TYPE_ZIP);
 	}
 
+	public DfuServiceInitiator setZipFromAssetsFile(@NonNull final String assetsFile) {
+		return init(assetsFile);
+	}
+
+
+	//fileAsseteName
+
 	/**
 	 * Sets the resource ID of the Distribution packet (ZIP) or the a ZIP file matching the
 	 * deprecated naming convention. The file should be in the /res/raw folder.
@@ -542,6 +550,11 @@ public class DfuServiceInitiator {
 	public DfuServiceInitiator setZip(@Nullable final Uri uri, @Nullable final String path) {
 		return init(uri, path, 0, DfuBaseService.TYPE_AUTO, DfuBaseService.MIME_TYPE_ZIP);
 	}
+
+
+
+
+
 
 	/**
 	 * Sets the URI of the BIN or HEX file containing the new firmware.
@@ -687,6 +700,7 @@ public class DfuServiceInitiator {
 		intent.putExtra(DfuBaseService.EXTRA_FILE_TYPE, fileType);
 		intent.putExtra(DfuBaseService.EXTRA_FILE_URI, fileUri);
 		intent.putExtra(DfuBaseService.EXTRA_FILE_PATH, filePath);
+		intent.putExtra(DfuBaseService.EXTRA_ASSETE_FILE_NAME, filePath);
 		intent.putExtra(DfuBaseService.EXTRA_FILE_RES_ID, fileResId);
 		intent.putExtra(DfuBaseService.EXTRA_INIT_FILE_URI, initFileUri);
 		intent.putExtra(DfuBaseService.EXTRA_INIT_FILE_PATH, initFilePath);
@@ -741,6 +755,24 @@ public class DfuServiceInitiator {
 		this.initFileResId = initFileResId;
 		return this;
 	}
+
+	private DfuServiceInitiator init(@Nullable final String fileAsseteName) {
+		this.fileUri = null;
+		this.filePath = null;
+		this.fileAsseteName = fileAsseteName;
+		this.fileResId = 0;
+		this.fileType = DfuBaseService.TYPE_AUTO;
+		this.mimeType = DfuBaseService.MIME_TYPE_ZIP;
+
+		// If the MIME TYPE implies it's a ZIP file then the init file must be included in the file.
+		if (DfuBaseService.MIME_TYPE_ZIP.equals(mimeType)) {
+			this.initFileUri = null;
+			this.initFilePath = null;
+			this.initFileResId = 0;
+		}
+		return this;
+	}
+
 
 	private DfuServiceInitiator init(@Nullable final Uri fileUri,
 									 @Nullable final String filePath,


### PR DESCRIPTION
Added functions that can be specified by assete file name in setZip

The reason is that when you bundle the update file you want to manage it under the assets folder.
The reason I want to put in the assets folder instead of raw is because I want to put a description of the update file in another folder of assets and manage it as a set.