### PR TITLE
Fixing copy/paste error in README

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -140,7 +140,7 @@ public class NotificationActivity extends Activity {
 }
 ```
 
-Remember to add your service to the *AndroidManifest.xml*.
+Remember to add your activity to the *AndroidManifest.xml*.
 
 Start the DFU service with the following code:
 


### PR DESCRIPTION
The readme has "Remember to add your service to AndroidManifest.xml" twice. The second time, it should say "Remember to add your *activity* to AndroidManifest.xml"