### PR TITLE
Added permission for FOREGROUND_SERVICE.

### DIFF
--- a/dfu/src/main/AndroidManifest.xml
+++ b/dfu/src/main/AndroidManifest.xml
@@ -3,4 +3,5 @@
 
 	<uses-permission android:name="android.permission.BLUETOOTH"/>
 	<uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
+	<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 </manifest>


### PR DESCRIPTION
This permission is required for [apps targeting API level 28+](https://developer.android.com/about/versions/pie/android-9.0-changes-28).