### PR TITLE
Fix for #221

### DIFF
--- a/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -94,7 +94,7 @@ import no.nordicsemi.android.error.GattError;
  * application.
  */
 @SuppressWarnings("deprecation")
-public abstract class DfuBaseService extends IntentService implements DfuProgressInfo.ProgressListener {
+public abstract class DfuBaseService extends IntentService implements DfuProgressVisualizer {
 	private static final String TAG = "DfuBaseService";
 
 	/* package */ static boolean DEBUG = false;
@@ -1642,10 +1642,6 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 		}
 	}
 
-	/**
-	 * Creates or updates the notification in the Notification Manager. Sends broadcast with
-	 * given progress state to the activity.
-	 */
 	@Override
 	public void updateProgressNotification() {
 		final DfuProgressInfo info = mProgressInfo;

--- a/dfu/src/main/java/no/nordicsemi/android/dfu/DfuProgressInfo.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/DfuProgressInfo.java
@@ -25,12 +25,16 @@ package no.nordicsemi.android.dfu;
 import android.os.SystemClock;
 import androidx.annotation.NonNull;
 
-/* package */ class DfuProgressInfo {
-	interface ProgressListener {
-		void updateProgressNotification();
-	}
-
-	private final ProgressListener mListener;
+// This class has been made public in 1.11.0 to allow Xamarin bindings.
+// See: https://github.com/NordicSemiconductor/Android-DFU-Library/issues/221
+/**
+ * This is an internal DFU class. Applications should not use it.
+ * It has public access modifier to allow Xamarin bindings.
+ * @since 1.11.0
+ */
+@SuppressWarnings("WeakerAccess")
+public class DfuProgressInfo {
+	private final DfuProgressVisualizer progressVisualizer;
 	private int progress;
 	private int bytesSent;
 	private int initialBytesSent;
@@ -42,16 +46,15 @@ import androidx.annotation.NonNull;
 	private int totalParts;
 	private long timeStart, lastProgressTime;
 
-	DfuProgressInfo(final @NonNull ProgressListener listener) {
-		mListener = listener;
+	DfuProgressInfo(final @NonNull DfuProgressVisualizer visualizer) {
+		this.progressVisualizer = visualizer;
 	}
 
-	DfuProgressInfo init(final int imageSizeInBytes, final int currentPart, final int totalParts) {
+	void init(final int imageSizeInBytes, final int currentPart, final int totalParts) {
 		this.imageSizeInBytes = imageSizeInBytes;
 		this.maxObjectSizeInBytes = Integer.MAX_VALUE; // by default the whole firmware will be sent as a single object
 		this.currentPart = currentPart;
 		this.totalParts = totalParts;
-		return this;
 	}
 
 	@SuppressWarnings({"UnusedReturnValue", "SameParameterValue"})
@@ -62,7 +65,7 @@ import androidx.annotation.NonNull;
 
 	void setProgress(final int progress) {
 		this.progress = progress;
-		mListener.updateProgressNotification();
+		progressVisualizer.updateProgressNotification();
 	}
 
 	void setBytesSent(final int bytesSent) {
@@ -72,7 +75,7 @@ import androidx.annotation.NonNull;
 		}
 		this.bytesSent = bytesSent;
 		this.progress = (int) (100.0f * bytesSent / imageSizeInBytes);
-		mListener.updateProgressNotification();
+		progressVisualizer.updateProgressNotification();
 	}
 
 	void addBytesSent(final int increment) {

--- a/dfu/src/main/java/no/nordicsemi/android/dfu/DfuProgressVisualizer.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/DfuProgressVisualizer.java
@@ -1,0 +1,17 @@
+package no.nordicsemi.android.dfu;
+
+// This class has been extracted from DfuProgressInfo in 1.11.0 to allow Xamarin bindings.
+// See: https://github.com/NordicSemiconductor/Android-DFU-Library/issues/221
+
+/**
+ * This is an internal DFU interface. Applications should not use it.
+ * It has public access modifier to allow Xamarin bindings.
+ * @since 1.11.0
+ */
+public interface DfuProgressVisualizer {
+	/**
+	 * Creates or updates the notification in the Notification Manager.
+	 * Sends broadcast with given progress state to the activity.
+	 */
+	void updateProgressNotification();
+}


### PR DESCRIPTION
This PR exposes `DfuProgressinfo` and its inner `ProgressListener` (renamed to `DfuProgressVisualizer`).
This is to make the Xamarin binding to work (see #221).