### PR TITLE
Clarification regarding bond restoration

### DIFF
--- a/dfu/src/main/java/no/nordicsemi/android/dfu/BaseCustomDfuImpl.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/BaseCustomDfuImpl.java
@@ -464,7 +464,8 @@ import no.nordicsemi.android.dfu.internal.exception.UploadAbortedException;
 
 			if (restoreBond && (mFileType & DfuBaseService.TYPE_APPLICATION) > 0) {
 				// Restore pairing when application was updated.
-				createBond();
+				if (!createBond())
+					logw("Creating bond failed");
 				alreadyWaited = false;
 			}
 		}


### PR DESCRIPTION
This PR clarifies the bond restoration API in the DFU library.
The clarification is required due to a bug on Android, that allows insecure connection despite bond information presence on Android. `BluetoothDevice.getBondState()` may return `BOND_BONDED` even if bonding isn't enabled (due to lack of bond information on the peripheral side). Android app has no clue whether the link is encrypted or not. 

Reported to Google, perhaps will be fixed in Android 11.