### PR TITLE
Add scan filter for Android 8.1.0 and onwards.

### DIFF
--- a/dfu/build.gradle
+++ b/dfu/build.gradle
@@ -19,7 +19,7 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core:1.5.0-alpha01'
+    implementation 'androidx.core:core:1.5.0-alpha05'
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.google.code.gson:gson:2.8.6'

--- a/dfu/src/main/java/no/nordicsemi/android/dfu/internal/scanner/BootloaderScannerLollipop.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/internal/scanner/BootloaderScannerLollipop.java
@@ -26,10 +26,13 @@ import android.annotation.TargetApi;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.le.BluetoothLeScanner;
 import android.bluetooth.le.ScanCallback;
+import android.bluetooth.le.ScanFilter;
 import android.bluetooth.le.ScanResult;
 import android.bluetooth.le.ScanSettings;
 import android.os.Build;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 /**
@@ -37,87 +40,96 @@ import java.util.Locale;
  */
 @TargetApi(Build.VERSION_CODES.LOLLIPOP)
 public class BootloaderScannerLollipop extends ScanCallback implements BootloaderScanner {
-	private final Object mLock = new Object();
-	private String mDeviceAddress;
-	private String mDeviceAddressIncremented;
-	private String mBootloaderAddress;
-	private boolean mFound;
+    private final Object mLock = new Object();
+    private String mDeviceAddress;
+    private String mDeviceAddressIncremented;
+    private String mBootloaderAddress;
+    private boolean mFound;
 
-	@Override
-	public String searchFor(final String deviceAddress) {
-		final String firstBytes = deviceAddress.substring(0, 15);
-		final String lastByte = deviceAddress.substring(15); // assuming that the device address is correct
-		final String lastByteIncremented = String.format(Locale.US, "%02X", (Integer.valueOf(lastByte, 16) + ADDRESS_DIFF) & 0xFF);
+    @Override
+    public String searchFor(final String deviceAddress) {
+        final String firstBytes = deviceAddress.substring(0, 15);
+        final String lastByte = deviceAddress.substring(15); // assuming that the device address is correct
+        final String lastByteIncremented = String.format(Locale.US, "%02X", (Integer.valueOf(lastByte, 16) + ADDRESS_DIFF) & 0xFF);
 
-		mDeviceAddress = deviceAddress;
-		mDeviceAddressIncremented = firstBytes + lastByteIncremented;
-		mBootloaderAddress = null;
-		mFound = false;
+        mDeviceAddress = deviceAddress;
+        mDeviceAddressIncremented = firstBytes + lastByteIncremented;
+        mBootloaderAddress = null;
+        mFound = false;
 
-		// Add timeout
-		new Thread(new Runnable() {
-			@Override
-			public void run() {
-				try {
-					Thread.sleep(BootloaderScanner.TIMEOUT);
-				} catch (final InterruptedException e) {
-					// do nothing
-				}
+        // Add timeout
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Thread.sleep(BootloaderScanner.TIMEOUT);
+                } catch (final InterruptedException e) {
+                    // do nothing
+                }
 
-				if (mFound)
-					return;
+                if (mFound)
+                    return;
 
-				mBootloaderAddress = null;
-				mFound = true;
+                mBootloaderAddress = null;
+                mFound = true;
 
-				// Notify the waiting thread
-				synchronized (mLock) {
-					mLock.notifyAll();
-				}
-			}
-		}, "Scanner timer").start();
+                // Notify the waiting thread
+                synchronized (mLock) {
+                    mLock.notifyAll();
+                }
+            }
+        }, "Scanner timer").start();
 
-		final BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
-		if (adapter == null || adapter.getState() != BluetoothAdapter.STATE_ON)
-			return null;
-		final BluetoothLeScanner scanner = adapter.getBluetoothLeScanner();
-		if (scanner == null)
-			return null;
-		/*
-		 * Scanning with filters does not work on Nexus 9 (Android 5.1). No devices are found and scanner terminates on timeout.
-		 * We will match the device address in the callback method instead. It's not like it should be, but at least it works.
-		 */
-		//final List<ScanFilter> filters = new ArrayList<>();
-		//filters.add(new ScanFilter.Builder().setDeviceAddress(mDeviceAddress).build());
-		//filters.add(new ScanFilter.Builder().setDeviceAddress(mDeviceAddressIncremented).build());
-		final ScanSettings settings = new ScanSettings.Builder().setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY).build();
-		scanner.startScan(/*filters*/ null, settings, this);
+        final BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
+        if (adapter == null || adapter.getState() != BluetoothAdapter.STATE_ON)
+            return null;
+        final BluetoothLeScanner scanner = adapter.getBluetoothLeScanner();
+        if (scanner == null)
+            return null;
+        /*
+         * Android 8.1 onwards, stops unfiltered BLE scanning on screen off. Therefore we must add a filter to
+         * get scan results in case the device screen is turned off as this may affect users wanting scan/connect to the device in background.
+         * See {@linktourl https://android.googlesource.com/platform/packages/apps/Bluetooth/+/319aeae6f4ebd13678b4f77375d1804978c4a1e1
+         */
+        final ScanSettings settings = new ScanSettings.Builder().setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY).build();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            final List<ScanFilter> filters = new ArrayList<>();
+            filters.add(new ScanFilter.Builder().setDeviceAddress(mDeviceAddress).build());
+            filters.add(new ScanFilter.Builder().setDeviceAddress(mDeviceAddressIncremented).build());
+            scanner.startScan(filters, settings, this);
+        } else {
+            /*
+             * Scanning with filters does not work on Nexus 9 (Android 5.1). No devices are found and scanner terminates on timeout.
+             * We will match the device address in the callback method instead. It's not like it should be, but at least it works.
+             */
+            scanner.startScan(null, settings, this);
+        }
 
-		try {
-			synchronized (mLock) {
-				while (!mFound)
-					mLock.wait();
-			}
-		} catch (final InterruptedException e) {
-			// do nothing
-		}
+        try {
+            synchronized (mLock) {
+                while (!mFound)
+                    mLock.wait();
+            }
+        } catch (final InterruptedException e) {
+            // do nothing
+        }
 
-		scanner.stopScan(this);
-		return mBootloaderAddress;
-	}
+        scanner.stopScan(this);
+        return mBootloaderAddress;
+    }
 
-	@Override
-	public void onScanResult(final int callbackType, final ScanResult result) {
-		final String address = result.getDevice().getAddress();
+    @Override
+    public void onScanResult(final int callbackType, final ScanResult result) {
+        final String address = result.getDevice().getAddress();
 
-		if (mDeviceAddress.equals(address) || mDeviceAddressIncremented.equals(address)) {
-			mBootloaderAddress = address;
-			mFound = true;
+        if (mDeviceAddress.equals(address) || mDeviceAddressIncremented.equals(address)) {
+            mBootloaderAddress = address;
+            mFound = true;
 
-			// Notify the waiting thread
-			synchronized (mLock) {
-				mLock.notifyAll();
-			}
-		}
-	}
+            // Notify the waiting thread
+            synchronized (mLock) {
+                mLock.notifyAll();
+            }
+        }
+    }
 }

--- a/dfu/src/main/java/no/nordicsemi/android/dfu/internal/scanner/BootloaderScannerLollipop.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/internal/scanner/BootloaderScannerLollipop.java
@@ -89,10 +89,10 @@ public class BootloaderScannerLollipop extends ScanCallback implements Bootloade
         /*
          * Android 8.1 onwards, stops unfiltered BLE scanning on screen off. Therefore we must add a filter to
          * get scan results in case the device screen is turned off as this may affect users wanting scan/connect to the device in background.
-         * See {@linktourl https://android.googlesource.com/platform/packages/apps/Bluetooth/+/319aeae6f4ebd13678b4f77375d1804978c4a1e1
+         * See {@linktourl https://android.googlesource.com/platform/packages/apps/Bluetooth/+/319aeae6f4ebd13678b4f77375d1804978c4a1e1}
          */
         final ScanSettings settings = new ScanSettings.Builder().setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY).build();
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+        if (adapter.isOffloadedFilteringSupported() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
             final List<ScanFilter> filters = new ArrayList<>();
             filters.add(new ScanFilter.Builder().setDeviceAddress(mDeviceAddress).build());
             filters.add(new ScanFilter.Builder().setDeviceAddress(mDeviceAddressIncremented).build());


### PR DESCRIPTION
* Adds a Scan Filter to the scanner when scanning for the device in bootloader mode. As of Android 8.1.0 when the screen is turned off, all scans without a scan filter will not receive any scan results as mentioned [here.](https://android.googlesource.com/platform/packages/apps/Bluetooth/+/319aeae6f4ebd13678b4f77375d1804978c4a1e1)