### PR TITLE
Workaround for hard disconnect and long supervision timeout

### DIFF
--- a/dfu/src/main/java/no/nordicsemi/android/dfu/ButtonlessDfuImpl.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/ButtonlessDfuImpl.java
@@ -145,12 +145,17 @@ import no.nordicsemi.android.error.SecureDfuError;
 				if (status != DFU_STATUS_SUCCESS)
 					throw new RemoteDfuException("Device returned error after sending Enter Bootloader", status);
 				// The device will reset so we don't have to send Disconnect signal.
-				mService.waitUntilDisconnected();
+				// Some devices don't disconnect gracefully. In that case, Android would assume disconnection
+				// after "supervision timeout" seconds, which may be 5 more seconds. There is no
+				// reason to wait for that. The library will immediately start scanning for the
+				// device advertising in bootloader mode and connect to it.
+				// mService.waitUntilDisconnected();
 			} else {
 				logi("Device disconnected before receiving notification");
 			}
 
-			mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_INFO, "Disconnected by the remote device");
+			// Commented out, see above comment.
+			// mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_INFO, "Disconnected by the remote device");
 
 			finalize(intent, false, shouldScanForBootloader());
 		} catch (final UnknownResponseException e) {

--- a/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyButtonlessDfuImpl.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyButtonlessDfuImpl.java
@@ -172,8 +172,12 @@ import no.nordicsemi.android.dfu.internal.exception.UploadAbortedException;
 		mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_APPLICATION, "Jump to bootloader sent (Op Code = 1, Upload Mode = 4)");
 
 		// The device will reset so we don't have to send Disconnect signal.
-		mService.waitUntilDisconnected();
-		mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_INFO, "Disconnected by the remote device");
+		// Some devices don't disconnect gracefully. In that case, Android would assume disconnection
+		// after "supervision timeout" seconds, which may be 5 more seconds. There is no
+		// reason to wait for that. The library will immediately start scanning for the
+		// device advertising in bootloader mode and connect to it.
+		// mService.waitUntilDisconnected();
+		// mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_INFO, "Disconnected by the remote device");
 
 		/*
 		 * We would like to avoid using the hack with refreshing the device (refresh method is not in the public API). The refresh method clears the cached services and causes a


### PR DESCRIPTION
In some DFU implementations the device reboots the hard way after switching from app mode to DFU bootloader mode. The disconnection event, sent to clients, depends in such case on supervision timeout, which may be quite long (5 seconds, or even 20). There is actually no need to wait for this, as the device actually reboots immediately. The service may start connecting to it immediately. The PR should fix issues with a bootloader timeout restarting the device back to app mode before the service even noticing that the device has disconnected.