### PR TITLE
Option to set scan delay, timeout and device selector when looking for Bootloader

### DIFF
--- a/lib_dfu/src/main/java/no/nordicsemi/android/dfu/BaseDfuImpl.java
+++ b/lib_dfu/src/main/java/no/nordicsemi/android/dfu/BaseDfuImpl.java
@@ -752,7 +752,7 @@ import no.nordicsemi.android.dfu.internal.scanner.BootloaderScannerFactory;
 		String newAddress = null;
 		if (scanForBootloader) {
 			final long delay = intent.getLongExtra(DfuBaseService.EXTRA_SCAN_DELAY, 0);
-			final long timeout = intent.getLongExtra(DfuBaseService.EXTRA_SCAN_TIMEOUT, 5000);
+			final long timeout = intent.getLongExtra(DfuBaseService.EXTRA_SCAN_TIMEOUT, DfuServiceInitiator.DEFAULT_SCAN_TIMEOUT);
 			mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_VERBOSE, "Scanning for the DFU Bootloader... (timeout " + timeout + " ms)");
 			if (delay > 0)
 				mService.waitFor(delay);

--- a/lib_dfu/src/main/java/no/nordicsemi/android/dfu/BaseDfuImpl.java
+++ b/lib_dfu/src/main/java/no/nordicsemi/android/dfu/BaseDfuImpl.java
@@ -751,8 +751,12 @@ import no.nordicsemi.android.dfu.internal.scanner.BootloaderScannerFactory;
 	void restartService(@NonNull final Intent intent, final boolean scanForBootloader) {
 		String newAddress = null;
 		if (scanForBootloader) {
-			mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_VERBOSE, "Scanning for the DFU Bootloader...");
-			newAddress = BootloaderScannerFactory.getScanner().searchFor(mGatt.getDevice().getAddress());
+			final long delay = intent.getIntExtra(DfuBaseService.EXTRA_SCAN_DELAY, 0);
+			final long timeout = intent.getIntExtra(DfuBaseService.EXTRA_SCAN_TIMEOUT, 5000);
+			mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_VERBOSE, "Scanning for the DFU Bootloader... (timeout " + timeout + " ms)");
+			if (delay > 0)
+				mService.waitFor(delay);
+			newAddress = BootloaderScannerFactory.getScanner(mGatt.getDevice().getAddress()).searchUsing(mService.getDeviceSelector(), timeout);
 			logi("Scanning for new address finished with: " + newAddress);
 			if (newAddress != null)
 				mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_INFO, "DFU Bootloader found with address " + newAddress);

--- a/lib_dfu/src/main/java/no/nordicsemi/android/dfu/BaseDfuImpl.java
+++ b/lib_dfu/src/main/java/no/nordicsemi/android/dfu/BaseDfuImpl.java
@@ -751,8 +751,8 @@ import no.nordicsemi.android.dfu.internal.scanner.BootloaderScannerFactory;
 	void restartService(@NonNull final Intent intent, final boolean scanForBootloader) {
 		String newAddress = null;
 		if (scanForBootloader) {
-			final long delay = intent.getIntExtra(DfuBaseService.EXTRA_SCAN_DELAY, 0);
-			final long timeout = intent.getIntExtra(DfuBaseService.EXTRA_SCAN_TIMEOUT, 5000);
+			final long delay = intent.getLongExtra(DfuBaseService.EXTRA_SCAN_DELAY, 0);
+			final long timeout = intent.getLongExtra(DfuBaseService.EXTRA_SCAN_TIMEOUT, 5000);
 			mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_VERBOSE, "Scanning for the DFU Bootloader... (timeout " + timeout + " ms)");
 			if (delay > 0)
 				mService.waitFor(delay);

--- a/lib_dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/lib_dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -734,6 +734,9 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 	 */
 	public static final int ACTION_ABORT = 2;
 
+	public static final String EXTRA_SCAN_DELAY = "no.nordicsemi.android.dfu.extra.EXTRA_SCAN_DELAY";
+	public static final String EXTRA_SCAN_TIMEOUT = "no.nordicsemi.android.dfu.extra.EXTRA_SCAN_TIMEOUT";
+
 	public static final String EXTRA_CUSTOM_UUIDS_FOR_LEGACY_DFU = "no.nordicsemi.android.dfu.extra.EXTRA_CUSTOM_UUIDS_FOR_LEGACY_DFU";
 	public static final String EXTRA_CUSTOM_UUIDS_FOR_SECURE_DFU = "no.nordicsemi.android.dfu.extra.EXTRA_CUSTOM_UUIDS_FOR_SECURE_DFU";
 	public static final String EXTRA_CUSTOM_UUIDS_FOR_EXPERIMENTAL_BUTTONLESS_DFU = "no.nordicsemi.android.dfu.extra.EXTRA_CUSTOM_UUIDS_FOR_EXPERIMENTAL_BUTTONLESS_DFU";
@@ -1941,6 +1944,17 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 	 */
 	@Nullable
 	protected abstract Class<? extends Activity> getNotificationTarget();
+
+	/**
+	 * This method should return the device selector, which is to be used to find the bootloader.
+	 * The default selector will look for a device with the same, or incremented device address.
+	 *
+	 * @return The device selector instance.
+	 */
+	@NonNull
+	protected DfuDeviceSelector getDeviceSelector() {
+		return new DfuDefaultDeviceSelector();
+	}
 
 	/**
 	 * Override this method to enable detailed debug LogCat logs with DFU events.

--- a/lib_dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/lib_dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -1950,6 +1950,7 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 	 * The default selector will look for a device with the same, or incremented device address.
 	 *
 	 * @return The device selector instance.
+	 * @since 2.1
 	 */
 	@NonNull
 	protected DfuDeviceSelector getDeviceSelector() {

--- a/lib_dfu/src/main/java/no/nordicsemi/android/dfu/DfuDefaultDeviceSelector.java
+++ b/lib_dfu/src/main/java/no/nordicsemi/android/dfu/DfuDefaultDeviceSelector.java
@@ -1,0 +1,18 @@
+package no.nordicsemi.android.dfu;
+
+import android.bluetooth.BluetoothDevice;
+
+import androidx.annotation.NonNull;
+
+class DfuDefaultDeviceSelector implements DfuDeviceSelector {
+    @Override
+    public boolean matches(
+            @NonNull final BluetoothDevice device,
+            final int rssi,
+            @NonNull final byte[] scanRecord,
+            @NonNull final String originalAddress,
+            @NonNull final String incrementedAddress) {
+        return originalAddress.equals(device.getAddress()) || incrementedAddress.equals(device.getAddress());
+    }
+}
+

--- a/lib_dfu/src/main/java/no/nordicsemi/android/dfu/DfuDefaultDeviceSelector.java
+++ b/lib_dfu/src/main/java/no/nordicsemi/android/dfu/DfuDefaultDeviceSelector.java
@@ -4,6 +4,13 @@ import android.bluetooth.BluetoothDevice;
 
 import androidx.annotation.NonNull;
 
+/**
+ * The default device selector looks for a device advertising an incremented address
+ * (the original address + 1). By returning a custom selector from
+ * {@link DfuBaseService#getDeviceSelector()} the app can override this behavior.
+ *
+ * @since 2.1
+ */
 class DfuDefaultDeviceSelector implements DfuDeviceSelector {
     @Override
     public boolean matches(

--- a/lib_dfu/src/main/java/no/nordicsemi/android/dfu/DfuDeviceSelector.java
+++ b/lib_dfu/src/main/java/no/nordicsemi/android/dfu/DfuDeviceSelector.java
@@ -4,7 +4,34 @@ import android.bluetooth.BluetoothDevice;
 
 import androidx.annotation.NonNull;
 
+/**
+ * The device selector can be used to filter scan results when scanning for the device
+ * advertising in bootloader mode.
+ * <p>
+ * By default, the scanner will look for a device advertising an incremented address
+ * (the original address + 1). By returning a custom selector from
+ * {@link DfuBaseService#getDeviceSelector()} the app can override this behavior.
+ *
+ * @see DfuDefaultDeviceSelector
+ * @since 2.1
+ */
 public interface DfuDeviceSelector {
+
+	/**
+	 * This method should return true if the given device matches the expected device in bootloader
+	 * mode.
+	 * <p>
+	 * The advertising data are given as a byte array for backwards compatibility with pre-Lollipop
+	 * devices.
+	 *
+	 * @param device the scanned Bluetooth device.
+	 * @param rssi the received signal strength indicator (RSSI) value for the device.
+	 * @param scanRecord the raw scan record of the device.
+	 * @param originalAddress the MAC address of the device when first connected.
+	 * @param incrementedAddress the incremented address of the device.
+	 * @return true if the device matches the expected device in bootloader mode.
+	 * @since 2.1
+	 */
 	boolean matches(
 			@NonNull final BluetoothDevice device,
 			final int rssi,

--- a/lib_dfu/src/main/java/no/nordicsemi/android/dfu/DfuDeviceSelector.java
+++ b/lib_dfu/src/main/java/no/nordicsemi/android/dfu/DfuDeviceSelector.java
@@ -1,0 +1,15 @@
+package no.nordicsemi.android.dfu;
+
+import android.bluetooth.BluetoothDevice;
+
+import androidx.annotation.NonNull;
+
+public interface DfuDeviceSelector {
+	boolean matches(
+			@NonNull final BluetoothDevice device,
+			final int rssi,
+			final @NonNull byte[] scanRecord,
+			final @NonNull String originalAddress,
+			final @NonNull String incrementedAddress
+	);
+}

--- a/lib_dfu/src/main/java/no/nordicsemi/android/dfu/DfuServiceInitiator.java
+++ b/lib_dfu/src/main/java/no/nordicsemi/android/dfu/DfuServiceInitiator.java
@@ -52,6 +52,7 @@ import androidx.annotation.RequiresApi;
 public final class DfuServiceInitiator {
 	public static final int DEFAULT_PRN_VALUE = 12;
 	public static final int DEFAULT_MBR_SIZE = 0x1000;
+	public static final long DEFAULT_SCAN_TIMEOUT = 5000; // ms
 
 	/** Constant used to narrow the scope of the update to system components (SD+BL) only. */
 	public static final int SCOPE_SYSTEM_COMPONENTS = 1;
@@ -85,7 +86,7 @@ public final class DfuServiceInitiator {
 	private int mbrSize = DEFAULT_MBR_SIZE;
 	private long dataObjectDelay = 0; // initially disabled
 	private long rebootTime = 0; // ms
-	private long scanTimeout = 5000; // ms
+	private long scanTimeout = DEFAULT_SCAN_TIMEOUT; // ms
 
 	private Boolean packetReceiptNotificationsEnabled;
 	private int numberOfPackets = 12;
@@ -135,8 +136,6 @@ public final class DfuServiceInitiator {
 		this.disableNotification = disableNotification;
 		return this;
 	}
-
-
 
 	/**
 	 * Sets whether the DFU service should be started as a foreground service. By default it's
@@ -274,8 +273,8 @@ public final class DfuServiceInitiator {
 	 * (except General Access and General Attribute services) - it assumes it is in DFU Bootloader
 	 * mode and may start DFU immediately, if there is at least one service except DFU Service -
 	 * the device is in application mode and supports buttonless jump. In the last case, if you
-	 * want to perform DFU operation without jumping - call the {@link #setForceDfu(boolean)}
-	 * method with parameter equal to true.
+	 * want to perform DFU operation without jumping - call the this method with parameter equal
+	 * to true.
 	 * <p>
 	 * This method is ignored in Secure DFU.
 	 *
@@ -284,7 +283,6 @@ public final class DfuServiceInitiator {
 	 * @return the builder
 	 * @see DfuSettingsConstants#SETTINGS_ASSUME_DFU_NODE
 	 */
-	@SuppressWarnings("JavaDoc")
 	public DfuServiceInitiator setForceDfu(final boolean force) {
 		this.forceDfu = force;
 		return this;
@@ -296,6 +294,7 @@ public final class DfuServiceInitiator {
 	 *
 	 * @param rebootTime the reboot time in milliseconds, default 0.
 	 * @return the builder
+	 * @since 2.1
 	 */
 	public DfuServiceInitiator setRebootTime(final long rebootTime) {
 		this.rebootTime = rebootTime;
@@ -305,8 +304,9 @@ public final class DfuServiceInitiator {
 	/**
 	 * Sets the scan duration (in milliseconds) when scanning for DFU Bootloader.
 	 *
-	 * @param scanTimeout the scan duration in milliseconds, default 5 seconds.
+	 * @param scanTimeout the scan duration in milliseconds, default {@value #DEFAULT_SCAN_TIMEOUT} ms.
 	 * @return the builder
+	 * @since 2.1
 	 */
 	public DfuServiceInitiator setScanTimeout(final long scanTimeout) {
 		this.scanTimeout = scanTimeout;

--- a/lib_dfu/src/main/java/no/nordicsemi/android/dfu/DfuServiceInitiator.java
+++ b/lib_dfu/src/main/java/no/nordicsemi/android/dfu/DfuServiceInitiator.java
@@ -84,6 +84,8 @@ public final class DfuServiceInitiator {
 	private int numberOfRetries = 0; // 0 to be backwards compatible
 	private int mbrSize = DEFAULT_MBR_SIZE;
 	private long dataObjectDelay = 0; // initially disabled
+	private long rebootTime = 0; // ms
+	private long scanTimeout = 5000; // ms
 
 	private Boolean packetReceiptNotificationsEnabled;
 	private int numberOfPackets = 12;
@@ -133,6 +135,8 @@ public final class DfuServiceInitiator {
 		this.disableNotification = disableNotification;
 		return this;
 	}
+
+
 
 	/**
 	 * Sets whether the DFU service should be started as a foreground service. By default it's
@@ -283,6 +287,29 @@ public final class DfuServiceInitiator {
 	@SuppressWarnings("JavaDoc")
 	public DfuServiceInitiator setForceDfu(final boolean force) {
 		this.forceDfu = force;
+		return this;
+	}
+
+	/**
+	 * Sets the time required by the device to reboot. The library will wait for this time before
+	 * scanning for the device in bootloader mode.
+	 *
+	 * @param rebootTime the reboot time in milliseconds, default 0.
+	 * @return the builder
+	 */
+	public DfuServiceInitiator setRebootTime(final long rebootTime) {
+		this.rebootTime = rebootTime;
+		return this;
+	}
+
+	/**
+	 * Sets the scan duration (in milliseconds) when scanning for DFU Bootloader.
+	 *
+	 * @param scanTimeout the scan duration in milliseconds, default 5 seconds.
+	 * @return the builder
+	 */
+	public DfuServiceInitiator setScanTimeout(final long scanTimeout) {
+		this.scanTimeout = scanTimeout;
 		return this;
 	}
 
@@ -816,6 +843,8 @@ public final class DfuServiceInitiator {
 		intent.putExtra(DfuBaseService.EXTRA_MAX_DFU_ATTEMPTS, numberOfRetries);
 		intent.putExtra(DfuBaseService.EXTRA_MBR_SIZE, mbrSize);
 		intent.putExtra(DfuBaseService.EXTRA_DATA_OBJECT_DELAY, dataObjectDelay);
+		intent.putExtra(DfuBaseService.EXTRA_SCAN_TIMEOUT, scanTimeout);
+		intent.putExtra(DfuBaseService.EXTRA_SCAN_DELAY, rebootTime);
 		if (mtu > 0)
 			intent.putExtra(DfuBaseService.EXTRA_MTU, mtu);
 		intent.putExtra(DfuBaseService.EXTRA_CURRENT_MTU, currentMtu);

--- a/lib_dfu/src/main/java/no/nordicsemi/android/dfu/DfuServiceListenerHelper.java
+++ b/lib_dfu/src/main/java/no/nordicsemi/android/dfu/DfuServiceListenerHelper.java
@@ -28,12 +28,11 @@ import android.content.Intent;
 import android.content.IntentFilter;
 
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 
 import androidx.annotation.NonNull;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
-import no.nordicsemi.android.dfu.internal.scanner.BootloaderScanner;
+import no.nordicsemi.android.dfu.internal.scanner.BootloaderScannerFactory;
 import no.nordicsemi.android.error.GattError;
 
 /**
@@ -67,7 +66,7 @@ public class DfuServiceListenerHelper {
 			// The new bootloader will afterwards advertise with the address incremented by 1.
 			// We need to make sure that the listener will receive also events from this device.
 			mListeners.put(deviceAddress, listener);
-			mListeners.put(getIncrementedAddress(deviceAddress), listener); // assuming the address is a valid BLE address
+			mListeners.put(BootloaderScannerFactory.getIncrementedAddress(deviceAddress), listener); // assuming the address is a valid BLE address
 		}
 
 		private boolean removeLogListener(final DfuLogListener listener) {
@@ -124,7 +123,7 @@ public class DfuServiceListenerHelper {
 			// When using the buttonless update and updating the SoftDevice the application will be removed to make space for the new SoftDevice.
 			// The new bootloader will afterwards advertise with the address incremented by 1. We need to make sure that the listener will receive also events from this device.
 			mListeners.put(deviceAddress, listener);
-			mListeners.put(getIncrementedAddress(deviceAddress), listener); // assuming the address is a valid BLE address
+			mListeners.put(BootloaderScannerFactory.getIncrementedAddress(deviceAddress), listener); // assuming the address is a valid BLE address
 		}
 
 		private boolean removeProgressListener(final DfuProgressListener listener) {
@@ -392,12 +391,5 @@ public class DfuServiceListenerHelper {
 				mLogBroadcastReceiver = null;
 			}
 		}
-	}
-
-	private static String getIncrementedAddress(@NonNull final String deviceAddress) {
-		final String firstBytes = deviceAddress.substring(0, 15);
-		final String lastByte = deviceAddress.substring(15); // assuming that the device address is correct
-		final String lastByteIncremented = String.format(Locale.US, "%02X", (Integer.valueOf(lastByte, 16) + BootloaderScanner.ADDRESS_DIFF) & 0xFF);
-		return firstBytes + lastByteIncremented;
 	}
 }

--- a/lib_dfu/src/main/java/no/nordicsemi/android/dfu/internal/scanner/BootloaderScanner.java
+++ b/lib_dfu/src/main/java/no/nordicsemi/android/dfu/internal/scanner/BootloaderScanner.java
@@ -22,7 +22,9 @@
 
 package no.nordicsemi.android.dfu.internal.scanner;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import no.nordicsemi.android.dfu.DfuDeviceSelector;
 
 /**
  * <p>
@@ -41,28 +43,18 @@ import androidx.annotation.Nullable;
  */
 public interface BootloaderScanner {
 	/**
-	 * After the buttonless jump from the application mode to the bootloader mode the service
-	 * will wait this long for the advertising bootloader (in milliseconds).
-	 */
-	long TIMEOUT = 5000L; // ms
-	/**
-	 * The bootloader may advertise with the same address or one with the last byte incremented
-	 * by this value. F.e. 00:11:22:33:44:55 -&gt; 00:11:22:33:44:56. FF changes to 00.
-	 */
-	int ADDRESS_DIFF = 1;
-
-	/**
 	 * Searches for the advertising bootloader. The bootloader may advertise with the same device
 	 * address or one with the last byte incremented by 1.
 	 * This method is a blocking one and ends when such device is found. There are two
 	 * implementations of this interface - one for Androids 4.3 and 4.4.x and one for the
 	 * Android 5+ devices.
 	 *
-	 * @param deviceAddress the application device address
+	 * @param selector the device selector
+	 * @param timeout the scanning timeout, in milliseconds
 	 * @return the address of the advertising DFU bootloader. It may be the same as the application
 	 * address or one with the last byte incremented by 1 (AA:BB:CC:DD:EE:45/FF -&gt; AA:BB:CC:DD:EE:46/00).
 	 * Null is returned when Bluetooth is off or the device has not been found.
 	 */
 	@Nullable
-	String searchFor(final String deviceAddress);
+	String searchUsing(final @NonNull DfuDeviceSelector selector, final long timeout);
 }

--- a/profile_dfu/src/main/java/no/nordicsemi/android/dfu/profile/main/repository/DFUService.kt
+++ b/profile_dfu/src/main/java/no/nordicsemi/android/dfu/profile/main/repository/DFUService.kt
@@ -31,17 +31,10 @@
 package no.nordicsemi.android.dfu.profile.main.repository
 
 import android.app.Activity
-import android.app.Notification
-import android.app.NotificationChannel
-import android.app.NotificationManager
-import android.content.Context
-import android.os.Build
-import androidx.annotation.RequiresApi
 import dagger.hilt.android.AndroidEntryPoint
 import no.nordicsemi.android.dfu.DfuBaseService
 import javax.inject.Inject
 import javax.inject.Singleton
-import no.nordicsemi.android.dfu.profile.R
 
 @Singleton
 internal class DFUServiceRunningObserver @Inject constructor() {
@@ -87,19 +80,5 @@ internal class DFUService : DfuBaseService() {
     override fun isDebug(): Boolean {
         // return BuildConfig.DEBUG;
         return true
-    }
-
-    @RequiresApi(api = Build.VERSION_CODES.O)
-    private fun createDfuNotificationChannel(context: Context) {
-        val channel = NotificationChannel(
-            NOTIFICATION_CHANNEL_DFU,
-            context.getString(R.string.dfu_channel_name),
-            NotificationManager.IMPORTANCE_LOW
-        )
-        channel.description = context.getString(R.string.dfu_channel_description)
-        channel.setShowBadge(false)
-        channel.lockscreenVisibility = Notification.VISIBILITY_PUBLIC
-        val notificationManager = context.getSystemService(NOTIFICATION_SERVICE) as NotificationManager
-        notificationManager.createNotificationChannel(channel)
     }
 }


### PR DESCRIPTION
This PR is intended to fix #338.

New features:
* [x] Option to set initial delay before scanning for DFU bootloader (some devices may need longer time to reboot) using https://github.com/NordicSemiconductor/Android-DFU-Library/blob/55651d4fbcfaf8df380d2cc02f1f4b0aa749d8b6/lib_dfu/src/main/java/no/nordicsemi/android/dfu/DfuServiceInitiator.java#L300
* [x] Option to set scan timeout using https://github.com/NordicSemiconductor/Android-DFU-Library/blob/55651d4fbcfaf8df380d2cc02f1f4b0aa749d8b6/lib_dfu/src/main/java/no/nordicsemi/android/dfu/DfuServiceInitiator.java#L311
* [x] Option to set custom device selector using https://github.com/NordicSemiconductor/Android-DFU-Library/blob/55651d4fbcfaf8df380d2cc02f1f4b0aa749d8b6/lib_dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java#L1955
* [x] Scan filters with MAC addresses were replaced with an empty scan filter. This should still allow background scanning, but should work on all phones. Hopefully.