### PR TITLE
FIx: Reconnection issue when the bootloader uses the same MAC as app

### DIFF
--- a/lib_dfu/src/main/java/no/nordicsemi/android/dfu/BaseButtonlessDfuImpl.java
+++ b/lib_dfu/src/main/java/no/nordicsemi/android/dfu/BaseButtonlessDfuImpl.java
@@ -86,22 +86,6 @@ import androidx.annotation.NonNull;
 		mService.close(mGatt);
 
 		/*
-		 * During the update the bonding information on the target device may have been removed.
-		 * To create bond with the new application set the EXTRA_RESTORE_BOND extra to true.
-		 * In case the bond information is copied to the new application the new bonding is not required.
-		 */
-		if (mGatt.getDevice().getBondState() == BluetoothDevice.BOND_BONDED) {
-			final boolean restoreBond = intent.getBooleanExtra(DfuBaseService.EXTRA_RESTORE_BOND, false);
-			if (restoreBond || !keepBond) {
-				// The bond information was lost.
-				removeBond();
-
-				// Give some time for removing the bond information. 300ms was to short, let's set it to 2 seconds just to be sure.
-				mService.waitFor(2000);
-			}
-		}
-
-		/*
 		 * The experimental buttonless service from SDK 12.x does not support sharing bond information
 		 * from the app to the bootloader. That means, that the DFU bootloader must advertise with advertise
 		 * with address +1 and must not be paired.

--- a/lib_dfu/src/main/java/no/nordicsemi/android/dfu/LegacyButtonlessDfuImpl.java
+++ b/lib_dfu/src/main/java/no/nordicsemi/android/dfu/LegacyButtonlessDfuImpl.java
@@ -173,13 +173,17 @@ import no.nordicsemi.android.dfu.internal.exception.UploadAbortedException;
 		writeOpCode(mControlPointCharacteristic, OP_CODE_ENTER_BOOTLOADER, true);
 		mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_APPLICATION, "Jump to bootloader sent (Op Code = 1, Upload Mode = 4)");
 
-		// The device will reset so we don't have to send Disconnect signal.
-		// Some devices don't disconnect gracefully. In that case, Android would assume disconnection
-		// after "supervision timeout" seconds, which may be 5 more seconds. There is no
-		// reason to wait for that. The library will immediately start scanning for the
-		// device advertising in bootloader mode and connect to it.
-		// mService.waitUntilDisconnected();
-		// mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_INFO, "Disconnected by the remote device");
+		// The device will disconnect and now reset. Some devices don't disconnect gracefully,
+		// but reset instead. In that case, Android would assume disconnection after
+		// "supervision timeout" seconds, which may be 5 more seconds. If the device will
+		// use a different address in bootloader mode, there is no reason to wait for that.
+		// The library will immediately start scanning for the device advertising in
+		// bootloader mode and connect to it.
+		final boolean forceScanning = intent.getBooleanExtra(DfuBaseService.EXTRA_FORCE_SCANNING_FOR_BOOTLOADER_IN_LEGACY_DFU, false);
+		if (/* scan only for SDK 6.1, see Pull request #45 */ forceScanning || mVersion == 0) {
+			mService.waitUntilDisconnected();
+			mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_INFO, "Disconnected by the remote device");
+		}
 
 		/*
 		 * We would like to avoid using the hack with refreshing the device (refresh method is not in the public API). The refresh method clears the cached services and causes a
@@ -203,8 +207,6 @@ import no.nordicsemi.android.dfu.internal.exception.UploadAbortedException;
 
 		// Close the device
 		mService.close(gatt);
-
-		final boolean forceScanning = intent.getBooleanExtra(DfuBaseService.EXTRA_FORCE_SCANNING_FOR_BOOTLOADER_IN_LEGACY_DFU, false);
 
 		logi("Starting service that will connect to the DFU bootloader");
 		final Intent newIntent = new Intent();


### PR DESCRIPTION
This PR fixes reconnection issue which happens when the device in bootloader mode is using the same MAC address as in app mode. This is when:
* In Secure DFU when Buttonless Service WITH Bonds is used
* In Legacy DFU by default, unless you call https://github.com/NordicSemiconductor/Android-DFU-Library/blob/7ceb23d27ed4233f9c62cd1020a9afd98313f2d4/lib_dfu/src/main/java/no/nordicsemi/android/dfu/DfuServiceInitiator.java#L334 with parameter `true` and compile the bootloader with required change.