### PR TITLE
DFU speed improvement (delays removed)

### DIFF
--- a/lib_dfu/src/main/java/no/nordicsemi/android/dfu/BaseCustomDfuImpl.java
+++ b/lib_dfu/src/main/java/no/nordicsemi/android/dfu/BaseCustomDfuImpl.java
@@ -454,7 +454,6 @@ import no.nordicsemi.android.dfu.internal.exception.UploadAbortedException;
 		 * To create bond with the new application set the EXTRA_RESTORE_BOND extra to true.
 		 * In case the bond information is copied to the new application the new bonding is not required.
 		 */
-		boolean alreadyWaited = false;
 		if (mGatt.getDevice().getBondState() == BluetoothDevice.BOND_BONDED) {
 			final boolean restoreBond = intent.getBooleanExtra(DfuBaseService.EXTRA_RESTORE_BOND, false);
 			if (restoreBond || !keepBond) {
@@ -464,14 +463,12 @@ import no.nordicsemi.android.dfu.internal.exception.UploadAbortedException;
 				// Give some time for removing the bond information. 300 ms was to short,
                 // let's set it to 2 seconds just to be sure.
 				mService.waitFor(2000);
-				alreadyWaited = true;
 			}
 
 			if (restoreBond && (mFileType & DfuBaseService.TYPE_APPLICATION) > 0) {
 				// Restore pairing when application was updated.
 				if (!createBond())
 					logw("Creating bond failed");
-				alreadyWaited = false;
 			}
 		}
 
@@ -483,9 +480,6 @@ import no.nordicsemi.android.dfu.internal.exception.UploadAbortedException;
 		 * In the first case we do not send PROGRESS_COMPLETED notification.
 		 */
 		if (mProgressInfo.isLastPart()) {
-			// Delay this event a little bit. Android needs some time to prepare for reconnection.
-			if (!alreadyWaited)
-				mService.waitFor(1400);
 			mProgressInfo.setProgress(DfuBaseService.PROGRESS_COMPLETED);
 		} else {
 			/*

--- a/lib_dfu/src/main/java/no/nordicsemi/android/dfu/ButtonlessDfuImpl.java
+++ b/lib_dfu/src/main/java/no/nordicsemi/android/dfu/ButtonlessDfuImpl.java
@@ -81,13 +81,6 @@ import no.nordicsemi.android.error.SecureDfuError;
             throws DfuException, DeviceDisconnectedException, UploadAbortedException {
 		mProgressInfo.setProgress(DfuBaseService.PROGRESS_STARTING);
 
-		// Add one second delay to avoid the traffic jam before the DFU mode is enabled
-		// Related:
-		//   issue:        https://github.com/NordicSemiconductor/Android-DFU-Library/issues/10
-		//   pull request: https://github.com/NordicSemiconductor/Android-DFU-Library/pull/12
-		mService.waitFor(1000);
-		// End
-
 		final BluetoothGatt gatt = mGatt;
 
 		// The service is connected to the application, not to the bootloader
@@ -100,12 +93,6 @@ import no.nordicsemi.android.error.SecureDfuError;
 		final int type = getResponseType();
 		enableCCCD(characteristic, getResponseType());
 		mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_APPLICATION, (type == INDICATIONS ? "Indications" : "Notifications") + " enabled");
-
-		// Wait a second here before going further
-		// Related:
-		//   pull request: https://github.com/NordicSemiconductor/Android-DFU-Library/pull/11
-		mService.waitFor(1000);
-		// End
 
 		try {
 			// Send 'enter bootloader command'

--- a/lib_dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/lib_dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -1289,13 +1289,6 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 				return;
 			}
 
-			if (!firstRun) {
-				// Wait a second... If we were connected before it's good to give some time before we start reconnecting.
-				waitFor(1000);
-				// Looks like a second is not enough. The ACL_DISCONNECTED broadcast sometimes comes later (on Android 7.0)
-				waitFor(1000);
-			}
-
 			mProgressInfo = new DfuProgressInfo(this);
 
 			if (mAborted) {

--- a/lib_dfu/src/main/java/no/nordicsemi/android/dfu/LegacyButtonlessDfuImpl.java
+++ b/lib_dfu/src/main/java/no/nordicsemi/android/dfu/LegacyButtonlessDfuImpl.java
@@ -71,13 +71,6 @@ import no.nordicsemi.android.dfu.internal.exception.UploadAbortedException;
 
 		mProgressInfo.setProgress(DfuBaseService.PROGRESS_STARTING);
 
-		// Add one second delay to avoid the traffic jam before the DFU mode is enabled
-		// Related:
-		//   issue:        https://github.com/NordicSemiconductor/Android-DFU-Library/issues/10
-		//   pull request: https://github.com/NordicSemiconductor/Android-DFU-Library/pull/12
-		mService.waitFor(1000);
-		// End
-
 		/*
 		 * Read the version number if available.
 		 * The DFU Version characteristic has been added in SDK 7.0.
@@ -160,12 +153,6 @@ import no.nordicsemi.android.dfu.internal.exception.UploadAbortedException;
 		// Enable notifications
 		enableCCCD(mControlPointCharacteristic, NOTIFICATIONS);
 		mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_APPLICATION, "Notifications enabled");
-
-		// Wait a second here before going further
-		// Related:
-		//   pull request: https://github.com/NordicSemiconductor/Android-DFU-Library/pull/11
-		mService.waitFor(1000);
-		// End
 
 		// Send 'jump to bootloader command' (Start DFU)
 		mProgressInfo.setProgress(DfuBaseService.PROGRESS_ENABLING_DFU_MODE);

--- a/lib_dfu/src/main/java/no/nordicsemi/android/dfu/LegacyDfuImpl.java
+++ b/lib_dfu/src/main/java/no/nordicsemi/android/dfu/LegacyDfuImpl.java
@@ -179,13 +179,6 @@ import no.nordicsemi.android.error.LegacyDfuError;
 			requestMtu(requiredMtu);
 		}
 
-		// Add one second delay to avoid the traffic jam before the DFU mode is enabled
-		// Related:
-		//   issue:        https://github.com/NordicSemiconductor/Android-DFU-Library/issues/10
-		//   pull request: https://github.com/NordicSemiconductor/Android-DFU-Library/pull/12
-		mService.waitFor(1000);
-		// End
-
 		final BluetoothGatt gatt = mGatt;
 
 		/*
@@ -211,12 +204,6 @@ import no.nordicsemi.android.error.LegacyDfuError;
 			// Enable notifications
 			enableCCCD(mControlPointCharacteristic, NOTIFICATIONS);
 			mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_APPLICATION, "Notifications enabled");
-
-			// Wait a second here before going further
-			// Related:
-			//   pull request: https://github.com/NordicSemiconductor/Android-DFU-Library/pull/11
-			mService.waitFor(1000);
-			// End
 
 			// Set up the temporary variable that will hold the responses
 			byte[] response;

--- a/lib_dfu/src/main/java/no/nordicsemi/android/dfu/SecureDfuImpl.java
+++ b/lib_dfu/src/main/java/no/nordicsemi/android/dfu/SecureDfuImpl.java
@@ -209,13 +209,6 @@ class SecureDfuImpl extends BaseCustomDfuImpl {
 		logw("Secure DFU bootloader found");
 		mProgressInfo.setProgress(DfuBaseService.PROGRESS_STARTING);
 
-		// Add one second delay to avoid the traffic jam before the DFU mode is enabled
-		// Related:
-		//   issue:        https://github.com/NordicSemiconductor/Android-DFU-Library/issues/10
-		//   pull request: https://github.com/NordicSemiconductor/Android-DFU-Library/pull/12
-		mService.waitFor(1000);
-		// End
-
 		final BluetoothGatt gatt = mGatt;
 
 		// Secure DFU since SDK 15 supports higher MTUs.
@@ -233,12 +226,6 @@ class SecureDfuImpl extends BaseCustomDfuImpl {
 			enableCCCD(mControlPointCharacteristic, NOTIFICATIONS);
 			mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_APPLICATION,
                     "Notifications enabled");
-
-			// Wait a second here before going further
-			// Related:
-			//   pull request: https://github.com/NordicSemiconductor/Android-DFU-Library/pull/11
-			mService.waitFor(1000);
-			// End
 
 			final boolean allowResume = !intent.hasExtra(DfuBaseService.EXTRA_DISABLE_RESUME)
 					|| !intent.getBooleanExtra(DfuBaseService.EXTRA_DISABLE_RESUME, false);


### PR DESCRIPTION
This PR removes number of `waitFor(... ms)` introduced in some places to support different phones.
Years passed and perhaps the devices where the issues were observed no longer need them. As an effect, this should make the DFU faster. Some delays have been left unchanged.

This PR fixes #329.

This change will not go to 2.1, but I'll release 2.2-beta01 just after 2.1 to allow testing. 