### PR TITLE
Improvement: disconnecting device when switching to dfu bootloader

### DIFF
--- a/lib_dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/lib_dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -1331,7 +1331,7 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 						loge("Device not reachable. Check if the device with address " + deviceAddress + " is in range, is advertising and is connectable");
 						sendLogBroadcast(LOG_LEVEL_ERROR, "Error 133: Connection timeout");
 					} else {
-						loge("An error occurred while connecting to the device:" + error);
+						loge("An error occurred while connecting to the device: " + error);
 						sendLogBroadcast(LOG_LEVEL_ERROR, String.format(Locale.US, "Connection failed (0x%02X): %s", error, GattError.parseConnectionError(error)));
 					}
 				} else {


### PR DESCRIPTION
This PR improves behavior with switching to DFU bootloader. Before, the library was either waiting until the connection is terminated or just starting scanning for the bootloader, hoping that the connection will terminate at some point. This, however, seemed to have issues on some devices, which were unable to connect to the device in bootloader mode for a long time.
Now, when the new address is expected, the device disconnects the connection to app mode before starting scanning for the bootloader.

Fixes #353 and #328.