### PR TITLE
Bug fix: Fixed crash when DFU Version characteristic returns no bytes

### DIFF
--- a/lib_dfu/src/main/java/no/nordicsemi/android/dfu/LegacyButtonlessDfuImpl.java
+++ b/lib_dfu/src/main/java/no/nordicsemi/android/dfu/LegacyButtonlessDfuImpl.java
@@ -231,6 +231,10 @@ import no.nordicsemi.android.dfu.internal.exception.UploadAbortedException;
 		if (mError != 0)
 			throw new DfuException("Unable to read version number", mError);
 
+		// The Version is encoded as UInt16
+		if (characteristic.getValue() == null || characteristic.getValue().length < 2)
+			return 0;
+
 		// The version is a 16-bit unsigned int
 		return characteristic.getIntValue(BluetoothGattCharacteristic.FORMAT_UINT16, 0);
 	}


### PR DESCRIPTION
This PR fixes a bug reported on Crashlitics.
As far as I understand, some Legacy DFU devices return 0 bytes from the DFU Version characteristic. This is not valid, but still, the lib should not crash.