### PR TITLE
[App] Bug fix: Error was not shown when the same failure scenario is repeated

### DIFF
--- a/profile_dfu/src/main/java/no/nordicsemi/android/dfu/profile/main/data/DFUProgressManager.kt
+++ b/profile_dfu/src/main/java/no/nordicsemi/android/dfu/profile/main/data/DFUProgressManager.kt
@@ -45,24 +45,8 @@ internal class DFUProgressManager @Inject constructor(
 ) : DfuProgressListenerAdapter() {
     val status = MutableStateFlow<DfuState>(DfuState.Idle)
 
-    override fun onDeviceConnecting(deviceAddress: String) {
-        status.value = DfuState.InProgress(Connecting)
-    }
-
-    override fun onDeviceConnected(deviceAddress: String) {
-        status.value = DfuState.InProgress(Connected)
-    }
-
-    override fun onDfuProcessStarting(deviceAddress: String) {
-        status.value = DfuState.InProgress(Starting)
-    }
-
-    override fun onDfuProcessStarted(deviceAddress: String) {
-        status.value = DfuState.InProgress(Started)
-    }
-
     override fun onEnablingDfuMode(deviceAddress: String) {
-        status.value = DfuState.InProgress(EnablingDfu)
+        status.value = DfuState.InProgress(InitializingDFU)
     }
 
     override fun onProgressChanged(
@@ -74,18 +58,6 @@ internal class DFUProgressManager @Inject constructor(
         partsTotal: Int
     ) {
         status.value = DfuState.InProgress(Uploading(percent, avgSpeed, currentPart, partsTotal))
-    }
-
-    override fun onFirmwareValidating(deviceAddress: String) {
-        status.value = DfuState.InProgress(Validating)
-    }
-
-    override fun onDeviceDisconnecting(deviceAddress: String?) {
-        status.value = DfuState.InProgress(Disconnecting)
-    }
-
-    override fun onDeviceDisconnected(deviceAddress: String) {
-        status.value = DfuState.InProgress(Disconnected)
     }
 
     override fun onDfuCompleted(deviceAddress: String) {
@@ -111,6 +83,10 @@ internal class DFUProgressManager @Inject constructor(
 
     fun unregisterListener() {
         DfuServiceListenerHelper.unregisterProgressListener(context, this)
+    }
+
+    fun start() {
+        status.value = DfuState.InProgress(Starting)
     }
 
     fun release() {

--- a/profile_dfu/src/main/java/no/nordicsemi/android/dfu/profile/main/data/DfuState.kt
+++ b/profile_dfu/src/main/java/no/nordicsemi/android/dfu/profile/main/data/DfuState.kt
@@ -41,11 +41,8 @@ sealed class DfuState {
 
 sealed class DfuProgress
 
-object Connecting : DfuProgress()
-object Connected : DfuProgress()
 object Starting : DfuProgress()
-object Started : DfuProgress()
-object EnablingDfu : DfuProgress()
+object InitializingDFU : DfuProgress()
 
 @Parcelize
 data class Uploading(
@@ -55,9 +52,6 @@ data class Uploading(
     val partsTotal: Int = 0
 ) : DfuProgress(), Parcelable
 
-object Validating : DfuProgress()
 object Completed : DfuProgress()
 object Aborted : DfuProgress()
-object Disconnecting : DfuProgress()
-object Disconnected : DfuProgress()
 data class Error(val message: String?) : DfuProgress()

--- a/profile_dfu/src/main/java/no/nordicsemi/android/dfu/profile/main/viewmodel/DFUViewModel.kt
+++ b/profile_dfu/src/main/java/no/nordicsemi/android/dfu/profile/main/viewmodel/DFUViewModel.kt
@@ -93,7 +93,10 @@ internal class DFUViewModel @Inject constructor(
             .mapNotNull { it.status }
             .onEach { status ->
                 when (status) {
-                    is EnablingDfu -> {
+                    is Starting -> {
+                        _state.value = _state.value.copy(progressViewEntity = DFUProgressViewEntity.createBootloaderStage())
+                    }
+                    is InitializingDFU -> {
                         _state.value = _state.value.copy(progressViewEntity = DFUProgressViewEntity.createDfuStage())
                     }
                     is Uploading -> {
@@ -173,9 +176,8 @@ internal class DFUViewModel @Inject constructor(
     }
 
     private fun onInstallButtonClick() = _state.value.settings?.let {
-        repository.launch(it)
-        _state.value = _state.value.copy(progressViewEntity = DFUProgressViewEntity.createBootloaderStage())
         analytics.logEvent(InstallationStartedEvent)
+        repository.launch(it)
     }
 
     private fun onZipFileSelected(uri: Uri) {


### PR DESCRIPTION
This PR fixes an issue with how the UI state was refreshed in case of an error (or, actually, when the DFU Process started).
The initial view of Progress section was refreshed without using `StateFlow`. If the first event received was an error, e.g when parsing a ZIP file, the `Flow` would refresh the UI. However, when this was repeated, as the initial view was refreshed without using state flow, it still contained the same error, so UI was not refreshed.

This PR changes this. Now, all UI state changes go through the flow.