### PR TITLE
Fix for issue 358

### DIFF
--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -1591,8 +1591,8 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 			return;
 
 		sendLogBroadcast(LOG_LEVEL_VERBOSE, "Disconnecting...");
-		mProgressInfo.setProgress(PROGRESS_DISCONNECTING);
 		mConnectionState = STATE_DISCONNECTING;
+		mProgressInfo.setProgress(PROGRESS_DISCONNECTING);
 
 		logi("Disconnecting from the device...");
 		sendLogBroadcast(LOG_LEVEL_DEBUG, "gatt.disconnect()");

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -1591,7 +1591,6 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 			return;
 
 		sendLogBroadcast(LOG_LEVEL_VERBOSE, "Disconnecting...");
-		mConnectionState = STATE_DISCONNECTING;
 		mProgressInfo.setProgress(PROGRESS_DISCONNECTING);
 
 		logi("Disconnecting from the device...");


### PR DESCRIPTION
I can reliably hit [Issue 358](https://github.com/NordicSemiconductor/Android-DFU-Library/issues/358) if I interrupt an in-progress DFU by pressing the RESET button on my custom hardware. It occurs due to a race condition between two threads. On thread 1, I have the stack trace `DfuBaseService:onHandleIntent:1428 -> DfuBaseService:terminateConnection:1571 -> DfuBaseService:disconnect`.  Thread 2 is with `DfuBaseService:onConnectionStateChange:932`.

When I hit the race condition, what happens is that I enter `disconnect` with `mConnectionState == STATE_CONNECTED_AND_READY`. By the time I hit line 1595, the second thread has run and I have `mConnectionState == STATE_DISCONNECTED`. Then set `mConnectionState = STATE_DISCONNECTING` is called, and later I enter `waitUntilDisconnected` and enter an endless loop while waiting for mConnectionState to be set back to STATE_DISCONNECTED.

My solution here is to remove the `mConnectionState = STATE_DISCONNECTING` call so that we can't go from STATE_DISCONNECTED -> STATE_DISCONNECTING. There is nowhere in the code where we look for `mConnectionState == STATE_DISCONNECTING`. Another solution might be to use a lock everywhere throughout the code when setting mConnectionState, but since that is more invasive I opted for the simple solution.

I have verified that this fixes the bug and causes the library to recognize a firmware upload failure due to GATT ERROR. 