### PR TITLE
doc: update flutter plugin to active version

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ A library for both iOS and Android that is based on this library is available fo
 ### Flutter
 
 A library for both iOS and Android that is based on this library is available for Flutter: 
-[flutter-nordic-dfu](https://github.com/fengqiangboy/flutter-nordic-dfu) 
+[nordic_dfu](https://github.com/juliansteenbakker/nordic_dfu) 
 
 ### Xamarin
 


### PR DESCRIPTION
The flutter plugin mentioned has been discontinued by the owner. I have forked and updated this plugin, so it would be best to mention the active version instead.