### PR TITLE
BLE API migrated to Tiramisu

### DIFF
--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/BaseButtonlessDfuImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/BaseButtonlessDfuImpl.java
@@ -40,8 +40,10 @@ import androidx.annotation.NonNull;
 
 	protected class ButtonlessBluetoothCallback extends BaseBluetoothGattCallback {
 		@Override
-		public void onCharacteristicChanged(final BluetoothGatt gatt, final BluetoothGattCharacteristic characteristic) {
-			mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_INFO, "Notification received from " + characteristic.getUuid() + ", value (0x): " + parse(characteristic));
+		public void onCharacteristicChanged(@NonNull final BluetoothGatt gatt,
+											@NonNull final BluetoothGattCharacteristic characteristic,
+											@NonNull final  byte[] value) {
+			mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_INFO, "Notification received from " + characteristic.getUuid() + ", value (0x): " + parse(value));
 			mReceivedData = characteristic.getValue();
 			notifyLock();
 		}


### PR DESCRIPTION
Android 13 improved the Bluetooth LE API.
To solve race conditions a new set of methods was added to split value from the `BluetoothGattCharacteristic` instance.

This PR migrates the library to the new API and solves related issues.