### PR TITLE
BLE API migrated to Tiramisu, fixed

### DIFF
--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyDfuImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyDfuImpl.java
@@ -93,13 +93,9 @@ import no.nordicsemi.android.error.LegacyDfuError;
 
 	protected class LegacyBluetoothCallback extends BaseCustomBluetoothCallback {
 		@Override
-		protected void onPacketCharacteristicWrite(@NonNull final BluetoothGatt gatt,
-												   @NonNull final BluetoothGattCharacteristic characteristic,
-												   final int status,
-												   @NonNull final byte[] value) {
+		protected void onPacketCharacteristicWrite() {
 			if (mImageSizeInProgress) {
 				// We've got confirmation that the image size was sent
-				mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_INFO, "Data written to " + characteristic.getUuid() + ", value (0x): " + parse(value));
 				mImageSizeInProgress = false;
 			}
 		}


### PR DESCRIPTION
This PR is a continuation of #405 which fixes an issue related to the empty characteristic value on Android Tiramisu+.