### PR TITLE
Support for Android 14, fixed

### DIFF
--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -1035,11 +1035,7 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 
 		final LocalBroadcastManager manager = LocalBroadcastManager.getInstance(this);
 		final IntentFilter actionFilter = makeDfuActionIntentFilter();
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-			this.registerReceiver(mDfuActionReceiver, actionFilter, RECEIVER_NOT_EXPORTED);
-		} else {
-			manager.registerReceiver(mDfuActionReceiver, actionFilter);
-		}
+		manager.registerReceiver(mDfuActionReceiver, actionFilter);
 		// Additionally we must register this receiver as a non-local to get broadcasts from the notification actions
 		ContextCompat.registerReceiver(this, mDfuActionReceiver, actionFilter, ContextCompat.RECEIVER_NOT_EXPORTED);
 

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -1037,7 +1037,7 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 		final IntentFilter actionFilter = makeDfuActionIntentFilter();
 		manager.registerReceiver(mDfuActionReceiver, actionFilter);
 		// Additionally we must register this receiver as a non-local to get broadcasts from the notification actions
-		ContextCompat.registerReceiver(this, mDfuActionReceiver, actionFilter, ContextCompat.RECEIVER_NOT_EXPORTED);
+		ContextCompat.registerReceiver(this, mDfuActionReceiver, actionFilter, ContextCompat.RECEIVER_EXPORTED);
 
 		final IntentFilter filter = new IntentFilter();
 		// As we no longer perform any action based on this broadcast, we may log all ACL events


### PR DESCRIPTION
This PR reverts #413 and fixes one issue with handling acton broadcasts sent from OS notifications, which are sent as global broadcasts (the receiver should therefore be exported).

I tested on 2 phones with Android 14 and none of them crashes on registering the received in `LocalBroadcastReceiver`.