### PR TITLE
[Bug fix] Crash when access to selected file was lost

### DIFF
--- a/profile/main/src/main/java/no/nordicsemi/android/dfu/profile/main/data/DFUFileManager.kt
+++ b/profile/main/src/main/java/no/nordicsemi/android/dfu/profile/main/data/DFUFileManager.kt
@@ -53,7 +53,8 @@ internal class DFUFileManager @Inject constructor(
             try {
                 createFromContentResolver(uri)
             } catch (e: Exception) {
-                Log.e(TAG, "Error loading file from content resolver.", e)
+                // Stack trace is too long, log just the message.
+                Log.e(TAG, "Error loading file from content resolver: ${e.localizedMessage}")
                 null
             }
         }

--- a/profile/main/src/main/java/no/nordicsemi/android/dfu/profile/main/data/DFUProgressManager.kt
+++ b/profile/main/src/main/java/no/nordicsemi/android/dfu/profile/main/data/DFUProgressManager.kt
@@ -71,6 +71,10 @@ internal class DFUProgressManager @Inject constructor(
         status.value = DfuState.InProgress(Aborted)
     }
 
+    fun onFileError() {
+        status.value = DfuState.InProgress(InvalidFile)
+    }
+
     override fun onError(
         deviceAddress: String,
         error: Int,

--- a/profile/main/src/main/java/no/nordicsemi/android/dfu/profile/main/data/DfuState.kt
+++ b/profile/main/src/main/java/no/nordicsemi/android/dfu/profile/main/data/DfuState.kt
@@ -41,6 +41,7 @@ internal sealed class DfuState {
 
 internal sealed class DfuProgress
 
+internal data object InvalidFile : DfuProgress()
 internal data object Starting : DfuProgress()
 internal data object InitializingDFU : DfuProgress()
 

--- a/profile/main/src/main/java/no/nordicsemi/android/dfu/profile/main/repository/DFURepository.kt
+++ b/profile/main/src/main/java/no/nordicsemi/android/dfu/profile/main/repository/DFURepository.kt
@@ -54,7 +54,7 @@ internal class DFURepository @Inject constructor(
     val data: StateFlow<DfuState> = _data.asStateFlow()
 
     var target: DfuTarget? = null
-    private var zipFile: ZipFile? = null
+    var zipFile: ZipFile? = null
     private var dfuServiceController: DfuServiceController? = null
 
     init {
@@ -67,9 +67,12 @@ internal class DFURepository @Inject constructor(
     fun setZipFile(file: Uri) = fileManger.createFile(file)?.also { zipFile = it }
 
     fun launch(settings: DFUSettings) {
-        progressManager.start()
-
-        dfuServiceController = dfuManager.install(zipFile!!, target!!, settings)
+        zipFile?.let { file ->
+            progressManager.start()
+            dfuServiceController = dfuManager.install(file, target!!, settings)
+        } ?: run {
+            progressManager.onFileError()
+        }
     }
 
     fun abort() {

--- a/profile/main/src/main/java/no/nordicsemi/android/dfu/profile/main/view/DFUSelectFileView.kt
+++ b/profile/main/src/main/java/no/nordicsemi/android/dfu/profile/main/view/DFUSelectFileView.kt
@@ -35,20 +35,16 @@ import android.content.ActivityNotFoundException
 import android.os.Parcelable
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.FolderZip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import kotlinx.parcelize.Parcelize
 import no.nordicsemi.android.common.core.parseBold
-import no.nordicsemi.android.common.theme.view.WizardStepComponent
 import no.nordicsemi.android.common.theme.view.WizardStepAction
+import no.nordicsemi.android.common.theme.view.WizardStepComponent
 import no.nordicsemi.android.common.theme.view.WizardStepState
 import no.nordicsemi.android.dfu.DfuBaseService
 import no.nordicsemi.android.dfu.profile.main.R
@@ -104,18 +100,16 @@ internal fun DFUNotSelectedFileView(viewEntity: NotSelectedFileViewEntity, onEve
         ),
         state = WizardStepState.CURRENT,
     ) {
-        Text(
-            text = stringResource(id = R.string.dfu_choose_info),
-            style = MaterialTheme.typography.bodyMedium,
-        )
         if (viewEntity.isError) {
-            Spacer(modifier = Modifier.size(8.dp))
-
             Text(
                 text = stringResource(id = R.string.dfu_load_file_error),
                 style = MaterialTheme.typography.labelMedium,
-                modifier = Modifier.padding(horizontal = 16.dp),
                 color = MaterialTheme.colorScheme.error
+            )
+        } else {
+            Text(
+                text = stringResource(id = R.string.dfu_choose_info),
+                style = MaterialTheme.typography.bodyMedium,
             )
         }
     }
@@ -154,18 +148,14 @@ internal fun DFUSelectFileView(
         ),
         state = WizardStepState.COMPLETED,
     ) {
-        Column(
-            horizontalAlignment = Alignment.Start
-        ) {
-            Text(
-                text = String.format(FILE_NAME, zipFile.name).parseBold(),
-                style = MaterialTheme.typography.bodyMedium
-            )
+        Text(
+            text = String.format(FILE_NAME, zipFile.name).parseBold(),
+            style = MaterialTheme.typography.bodyMedium
+        )
 
-            Text(
-                text = String.format(FILE_SIZE, zipFile.size).parseBold(),
-                style = MaterialTheme.typography.bodyMedium,
-            )
-        }
+        Text(
+            text = String.format(FILE_SIZE, zipFile.size).parseBold(),
+            style = MaterialTheme.typography.bodyMedium,
+        )
     }
 }

--- a/profile/main/src/main/res/values/strings.xml
+++ b/profile/main/src/main/res/values/strings.xml
@@ -33,7 +33,7 @@
 <resources>
     <string name="dfu_title">Firmware Upgrade</string>
 
-    <string name="dfu_load_file_error">An error occurred during loading the file. Please try with another file.</string>
+    <string name="dfu_load_file_error">An error occurred during loading the file.\nPlease try again or select another file.</string>
 
     <string name="dfu_choose_not_selected">Not selected</string>
     <string name="dfu_choose_selected">Selected</string>


### PR DESCRIPTION
It is possible to do the following:
1. Start DFU to a selected target device
2. Quit the app with a Back button when DFU is in progress -> this will kill the Activity and ViewModel
3. When DFU is complete (it runs in a foreground service, so wasn't affected) open app again
4. The app shows correctly status of the last operation
5. Try to do DFU again to the same or other device (without modifying the file)
6. This will cause a crash, as access to the file was granted for URI, which is no longer active

This PR fixes that by displaying an error instead. User can select the file again and repeat DFU.