### PR TITLE
Display device name from advertising packet first, then from the device

### DIFF
--- a/profile/scanner/src/main/java/no/nordicsemi/android/dfu/profile/scanner/data/DfuTarget.kt
+++ b/profile/scanner/src/main/java/no/nordicsemi/android/dfu/profile/scanner/data/DfuTarget.kt
@@ -9,5 +9,5 @@ data class DfuTarget(
     val address: String,
     val name: String?,
 ): Parcelable {
-    internal constructor(result: ServerDevice): this(result.address, result.name)
+    internal constructor(result: ServerDevice, name: String?): this(result.address, name)
 }

--- a/profile/scanner/src/main/java/no/nordicsemi/android/dfu/profile/scanner/view/ScannerContent.kt
+++ b/profile/scanner/src/main/java/no/nordicsemi/android/dfu/profile/scanner/view/ScannerContent.kt
@@ -18,7 +18,13 @@ internal fun ScannerContent() {
         onResult = { result ->
             when (result) {
                 ScanningCancelled -> vm.navigateUp()
-                is DeviceSelected -> vm.navigateUpWithResult(Scanner, DfuTarget(result.scanResults.device))
+                is DeviceSelected -> vm.navigateUpWithResult(
+                    from = Scanner,
+                    result = DfuTarget(
+                        result = result.scanResults.device,
+                        name = result.scanResults.scanResult.firstNotNullOfOrNull { it.scanRecord?.deviceName } ?: result.scanResults.device.name
+                    )
+                )
             }
         },
     )


### PR DESCRIPTION
This PR changes which name is shown on the screen.
The advertised name takes priority over the one from `BluetoothDevice`, which can be old (cached).