### PR TITLE
Dependencies updated

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("no.nordicsemi.android.gradle:version-catalog:1.9.15")
+            from("no.nordicsemi.android.gradle:version-catalog:1.9.17")
         }
     }
 }


### PR DESCRIPTION
[Nordic Android Gradle Plugin 1.10.0](https://github.com/NordicSemiconductor/Android-Gradle-Plugins/releases/tag/1.10.0) switched to Material3 version `1.2.0-alpha11`, which has this bug:
https://issuetracker.google.com/issues/310341877

Instead, a [1.9.17](https://github.com/NordicSemiconductor/Android-Gradle-Plugins/releases/tag/1.9.17) version was released with the stable Material3 version.