### PR TITLE
Reverting DFU Library to Java 11

### DIFF
--- a/lib/dfu/build.gradle.kts
+++ b/lib/dfu/build.gradle.kts
@@ -61,8 +61,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 }
 

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/BaseDfuImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/BaseDfuImpl.java
@@ -275,12 +275,16 @@ import no.nordicsemi.android.dfu.internal.scanner.BootloaderScannerFactory;
 		}
 
 		private String phyToString(final int phy) {
-			return switch (phy) {
-				case BluetoothDevice.PHY_LE_1M -> "LE 1M";
-				case BluetoothDevice.PHY_LE_2M -> "LE 2M";
-				case BluetoothDevice.PHY_LE_CODED -> "LE Coded";
-				default -> "UNKNOWN (" + phy + ")";
-			};
+			switch (phy) {
+				case BluetoothDevice.PHY_LE_1M:
+					return "LE 1M";
+				case BluetoothDevice.PHY_LE_2M:
+					return "LE 2M";
+				case BluetoothDevice.PHY_LE_CODED:
+					return "LE Coded";
+				default:
+					return "UNKNOWN (" + phy + ")";
+			}
 		}
 	}
 

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -788,21 +788,24 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 
 			logi("User action received: " + action);
 			switch (action) {
-				case ACTION_PAUSE -> {
+				case ACTION_PAUSE: {
 					sendLogBroadcast(LOG_LEVEL_WARNING, "[Broadcast] Pause action received");
 					if (mDfuServiceImpl != null)
 						mDfuServiceImpl.pause();
+					break;
 				}
-				case ACTION_RESUME -> {
+				case ACTION_RESUME: {
 					sendLogBroadcast(LOG_LEVEL_WARNING, "[Broadcast] Resume action received");
 					if (mDfuServiceImpl != null)
 						mDfuServiceImpl.resume();
+					break;
 				}
-				case ACTION_ABORT -> {
+				case ACTION_ABORT: {
 					sendLogBroadcast(LOG_LEVEL_WARNING, "[Broadcast] Abort action received");
 					mAborted = true;
 					if (mDfuServiceImpl != null)
 						mDfuServiceImpl.abort();
+					break;
 				}
 			}
 		}
@@ -1722,45 +1725,52 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 		builder.setColor(Color.GRAY);
 
 		switch (progress) {
-			case PROGRESS_CONNECTING ->
+			case PROGRESS_CONNECTING:
 					builder.setOngoing(true)
 							.setContentTitle(getString(R.string.dfu_status_connecting))
 							.setContentText(getString(R.string.dfu_status_connecting_msg, deviceName))
 							.setProgress(100, 0, true);
-			case PROGRESS_STARTING ->
+				break;
+			case PROGRESS_STARTING:
 					builder.setOngoing(true)
 							.setContentTitle(getString(R.string.dfu_status_starting))
 							.setContentText(getString(R.string.dfu_status_starting_msg))
 							.setProgress(100, 0, true);
-			case PROGRESS_ENABLING_DFU_MODE ->
+				break;
+			case PROGRESS_ENABLING_DFU_MODE:
 					builder.setOngoing(true)
 							.setContentTitle(getString(R.string.dfu_status_switching_to_dfu))
 							.setContentText(getString(R.string.dfu_status_switching_to_dfu_msg))
 							.setProgress(100, 0, true);
-			case PROGRESS_VALIDATING ->
+				break;
+			case PROGRESS_VALIDATING:
 					builder.setOngoing(true)
 							.setContentTitle(getString(R.string.dfu_status_validating))
 							.setContentText(getString(R.string.dfu_status_validating_msg))
 							.setProgress(100, 0, true);
-			case PROGRESS_DISCONNECTING ->
+				break;
+			case PROGRESS_DISCONNECTING:
 					builder.setOngoing(true)
 							.setContentTitle(getString(R.string.dfu_status_disconnecting))
 							.setContentText(getString(R.string.dfu_status_disconnecting_msg, deviceName))
 							.setProgress(100, 0, true);
-			case PROGRESS_COMPLETED ->
+				break;
+			case PROGRESS_COMPLETED:
 					builder.setOngoing(false)
 							.setContentTitle(getString(R.string.dfu_status_completed))
 							.setSmallIcon(android.R.drawable.stat_sys_upload_done)
 							.setContentText(getString(R.string.dfu_status_completed_msg))
 							.setAutoCancel(true)
 							.setColor(0xFF00B81A);
-			case PROGRESS_ABORTED ->
+				break;
+			case PROGRESS_ABORTED:
 					builder.setOngoing(false)
 							.setContentTitle(getString(R.string.dfu_status_aborted))
 							.setSmallIcon(android.R.drawable.stat_sys_upload_done)
 							.setContentText(getString(R.string.dfu_status_aborted_msg))
 							.setAutoCancel(true);
-			default -> {
+				break;
+			default: {
 				// progress is in percents
 				final String title = info.getTotalParts() == 1 ?
 						getString(R.string.dfu_status_uploading) :
@@ -1768,6 +1778,7 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 				final String text = getString(R.string.dfu_status_uploading_msg, deviceName);
 				builder.setOngoing(true).setContentTitle(title).setContentText(text)
 						.setProgress(100, progress, false);
+				break;
 			}
 		}
 

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuServiceListenerHelper.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuServiceListenerHelper.java
@@ -165,7 +165,7 @@ public class DfuServiceListenerHelper {
 				return;
 
 			switch (action) {
-				case DfuBaseService.BROADCAST_PROGRESS -> {
+				case DfuBaseService.BROADCAST_PROGRESS: {
 					final int progress = intent.getIntExtra(DfuBaseService.EXTRA_DATA, 0);
 					final float speed = intent.getFloatExtra(DfuBaseService.EXTRA_SPEED_B_PER_MS, 0.0f);
 					final float avgSpeed = intent.getFloatExtra(DfuBaseService.EXTRA_AVG_SPEED_B_PER_MS, 0.0f);
@@ -173,13 +173,13 @@ public class DfuServiceListenerHelper {
 					final int partsTotal = intent.getIntExtra(DfuBaseService.EXTRA_PARTS_TOTAL, 0);
 
 					switch (progress) {
-						case DfuBaseService.PROGRESS_CONNECTING -> {
+						case DfuBaseService.PROGRESS_CONNECTING:
 							if (globalListener != null)
 								globalListener.onDeviceConnecting(address);
 							if (deviceListener != null)
 								deviceListener.onDeviceConnecting(address);
-						}
-						case DfuBaseService.PROGRESS_STARTING -> {
+							break;
+						case DfuBaseService.PROGRESS_STARTING:
 							if (globalListener != null) {
 								globalListener.onDeviceConnected(address);
 								globalListener.onDfuProcessStarting(address);
@@ -188,26 +188,26 @@ public class DfuServiceListenerHelper {
 								deviceListener.onDeviceConnected(address);
 								deviceListener.onDfuProcessStarting(address);
 							}
-						}
-						case DfuBaseService.PROGRESS_ENABLING_DFU_MODE -> {
+							break;
+						case DfuBaseService.PROGRESS_ENABLING_DFU_MODE:
 							if (globalListener != null)
 								globalListener.onEnablingDfuMode(address);
 							if (deviceListener != null)
 								deviceListener.onEnablingDfuMode(address);
-						}
-						case DfuBaseService.PROGRESS_VALIDATING -> {
+							break;
+						case DfuBaseService.PROGRESS_VALIDATING:
 							if (globalListener != null)
 								globalListener.onFirmwareValidating(address);
 							if (deviceListener != null)
 								deviceListener.onFirmwareValidating(address);
-						}
-						case DfuBaseService.PROGRESS_DISCONNECTING -> {
+							break;
+						case DfuBaseService.PROGRESS_DISCONNECTING:
 							if (globalListener != null)
 								globalListener.onDeviceDisconnecting(address);
 							if (deviceListener != null)
 								deviceListener.onDeviceDisconnecting(address);
-						}
-						case DfuBaseService.PROGRESS_COMPLETED -> {
+							break;
+						case DfuBaseService.PROGRESS_COMPLETED:
 							if (globalListener != null) {
 								globalListener.onDeviceDisconnected(address);
 								globalListener.onDfuCompleted(address);
@@ -216,8 +216,8 @@ public class DfuServiceListenerHelper {
 								deviceListener.onDeviceDisconnected(address);
 								deviceListener.onDfuCompleted(address);
 							}
-						}
-						case DfuBaseService.PROGRESS_ABORTED -> {
+							break;
+						case DfuBaseService.PROGRESS_ABORTED:
 							if (globalListener != null) {
 								globalListener.onDeviceDisconnected(address);
 								globalListener.onDfuAborted(address);
@@ -226,8 +226,8 @@ public class DfuServiceListenerHelper {
 								deviceListener.onDeviceDisconnected(address);
 								deviceListener.onDfuAborted(address);
 							}
-						}
-						default -> {
+							break;
+						default:
 							if (progress == 0) {
 								if (globalListener != null)
 									globalListener.onDfuProcessStarted(address);
@@ -238,11 +238,12 @@ public class DfuServiceListenerHelper {
 								globalListener.onProgressChanged(address, progress, speed, avgSpeed, currentPart, partsTotal);
 							if (deviceListener != null)
 								deviceListener.onProgressChanged(address, progress, speed, avgSpeed, currentPart, partsTotal);
-						}
+							break;
 					}
 
+					break;
 				}
-				case DfuBaseService.BROADCAST_ERROR -> {
+				case DfuBaseService.BROADCAST_ERROR: {
 					final int error = intent.getIntExtra(DfuBaseService.EXTRA_DATA, 0);
 					final int errorType = intent.getIntExtra(DfuBaseService.EXTRA_ERROR_TYPE, 0);
 
@@ -251,24 +252,24 @@ public class DfuServiceListenerHelper {
 					if (deviceListener != null)
 						deviceListener.onDeviceDisconnected(address);
 					switch (errorType) {
-						case DfuBaseService.ERROR_TYPE_COMMUNICATION_STATE -> {
+						case DfuBaseService.ERROR_TYPE_COMMUNICATION_STATE:
 							if (globalListener != null)
 								globalListener.onError(address, error, errorType, GattError.parseConnectionError(error));
 							if (deviceListener != null)
 								deviceListener.onError(address, error, errorType, GattError.parseConnectionError(error));
-						}
-						case DfuBaseService.ERROR_TYPE_DFU_REMOTE -> {
+							break;
+						case DfuBaseService.ERROR_TYPE_DFU_REMOTE:
 							if (globalListener != null)
 								globalListener.onError(address, error, errorType, GattError.parseDfuRemoteError(error));
 							if (deviceListener != null)
 								deviceListener.onError(address, error, errorType, GattError.parseDfuRemoteError(error));
-						}
-						default -> {
+							break;
+						default:
 							if (globalListener != null)
 								globalListener.onError(address, error, errorType, GattError.parse(error));
 							if (deviceListener != null)
 								deviceListener.onError(address, error, errorType, GattError.parse(error));
-						}
+							break;
 					}
 				}
 			}

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyButtonlessDfuImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyButtonlessDfuImpl.java
@@ -247,15 +247,21 @@ import no.nordicsemi.android.dfu.internal.exception.UploadAbortedException;
 	}
 
 	private String getVersionFeatures(final int version) {
-		return switch (version) {
-			case 0 -> "Bootloader from SDK 6.1 or older";
-			case 1 -> "Application with Legacy buttonless update from SDK 7.0 or newer";
-			case 5 -> "Bootloader from SDK 7.0 or newer. No bond sharing";
-			case 6 -> "Bootloader from SDK 8.0 or newer. Bond sharing supported";
-			case 7 ->
-					"Bootloader from SDK 8.0 or newer. SHA-256 used instead of CRC-16 in the Init Packet";
-			case 8 -> "Bootloader from SDK 9.0 or newer. Signature supported";
-			default -> "Unknown version";
-		};
+		switch (version) {
+			case 0:
+				return "Bootloader from SDK 6.1 or older";
+			case 1:
+				return "Application with Legacy buttonless update from SDK 7.0 or newer";
+			case 5:
+				return "Bootloader from SDK 7.0 or newer. No bond sharing";
+			case 6:
+				return "Bootloader from SDK 8.0 or newer. Bond sharing supported";
+			case 7:
+				return "Bootloader from SDK 8.0 or newer. SHA-256 used instead of CRC-16 in the Init Packet";
+			case 8:
+				return "Bootloader from SDK 9.0 or newer. Signature supported";
+			default:
+				return "Unknown version";
+		}
 	}
 }

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyDfuImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyDfuImpl.java
@@ -242,7 +242,8 @@ import no.nordicsemi.android.error.LegacyDfuError;
 			int bootloaderImageSize = (fileType & DfuBaseService.TYPE_BOOTLOADER) > 0 ? mImageSizeInBytes : 0;
 			int appImageSize = (fileType & DfuBaseService.TYPE_APPLICATION) > 0 ? mImageSizeInBytes : 0;
 			// The sizes above may be overwritten if a ZIP file was passed
-			if (mFirmwareStream instanceof final ArchiveInputStream zhis) {
+			if (mFirmwareStream instanceof ArchiveInputStream) {
+				final ArchiveInputStream zhis = (ArchiveInputStream) mFirmwareStream;
 				if (zhis.isSecureDfuRequired()) {
 					loge("Secure DFU is required to upload selected firmware");
 					mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_ERROR, "The device does not support given firmware.");

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/SecureDfuImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/SecureDfuImpl.java
@@ -107,9 +107,9 @@ class SecureDfuImpl extends BaseCustomDfuImpl {
 
 				//noinspection SwitchStatementWithTooFewBranches
 				switch (requestType) {
-					case OP_CODE_CALCULATE_CHECKSUM_KEY -> {
-						final int offset = getInt(value, 3);
-						final int remoteCrc = getInt(value, 7);
+					case OP_CODE_CALCULATE_CHECKSUM_KEY: {
+						final int offset = characteristic.getIntValue(BluetoothGattCharacteristic.FORMAT_UINT32, 3);
+						final int remoteCrc = characteristic.getIntValue(BluetoothGattCharacteristic.FORMAT_UINT32, 3 + 4);
 						final int localCrc = (int) (((ArchiveInputStream) mFirmwareStream).getCrc32() & 0xFFFFFFFFL);
 						// Check whether local and remote CRC match
 						if (localCrc == remoteCrc) {
@@ -125,8 +125,9 @@ class SecureDfuImpl extends BaseCustomDfuImpl {
 							} // else will be handled by sendFirmware(gatt) below
 						}
 						handlePacketReceiptNotification(gatt, characteristic, value);
+						break;
 					}
-					default -> {
+					default: {
 						/*
 						 * If the DFU target device is in invalid state (e.g. the Init Packet is
 						 * required but has not been selected), the target will send
@@ -140,6 +141,7 @@ class SecureDfuImpl extends BaseCustomDfuImpl {
 							mRemoteErrorOccurred = true;
 
 						handleNotification(gatt, characteristic, value);
+						break;
 					}
 				}
 			} else {
@@ -284,7 +286,8 @@ class SecureDfuImpl extends BaseCustomDfuImpl {
                     "Remote DFU error: %s", SecureDfuError.parse(error)));
 
 			// For the Extended Error more details can be obtained on some devices.
-			if (e instanceof final RemoteDfuExtendedErrorException ee) {
+			if (e instanceof RemoteDfuExtendedErrorException) {
+				final RemoteDfuExtendedErrorException ee = (RemoteDfuExtendedErrorException) e;
 				final int extendedError = DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | ee.getExtendedErrorNumber();
 				loge("Extended Error details: " + SecureDfuError.parseExtendedError(extendedError));
 				mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_ERROR,

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/internal/ArchiveInputStream.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/internal/ArchiveInputStream.java
@@ -371,10 +371,9 @@ public class ArchiveInputStream extends InputStream {
 			final ManifestFile manifestFile = new Gson().fromJson(manifestData, ManifestFile.class);
 			manifest = manifestFile.getManifest();
 			if (manifest == null) {
-				Log.w(TAG, """
-						Manifest failed to be parsed. Did you add\s
-						-keep class no.nordicsemi.android.dfu.** { *; }
-						to your proguard rules?""");
+				Log.w(TAG, "Manifest failed to be parsed. Did you add \n" +
+						"-keep class no.nordicsemi.android.dfu.** { *; }\n" +
+						"to your proguard rules?");
 			}
 		} else {
 			Log.w(TAG, "Manifest not found in the ZIP. It is recommended to use a distribution " +

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/internal/HexInputStream.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/internal/HexInputStream.java
@@ -278,19 +278,18 @@ public class HexInputStream extends FilterInputStream {
 
 			// if the line type is no longer data type (0x00), we've reached the end of the file
 			switch (type) {
-				case 0x00 -> {
+				case 0x00:
 					// data type
 					if (lastAddress + offset < MBRSize) { // skip MBR
 						type = -1; // some other than 0
 						pos += skip(in, lineSize * 2L /* 2 hex per one byte */ + 2 /* check sum */);
 					}
-				}
-				case 0x01 -> {
+					break;
+				case 0x01:
 					// end of file
 					pos = -1;
 					return 0;
-				}
-				case 0x02 -> {
+				case 0x02: {
 					// extended segment address
 					final int address = readAddress(in) << 4;
 					pos += 4;
@@ -298,8 +297,9 @@ public class HexInputStream extends FilterInputStream {
 						return 0;
 					lastAddress = address;
 					pos += skip(in, 2 /* check sum */);
+					break;
 				}
-				case 0x04 -> {
+				case 0x04: {
 					// extended linear address
 					final int address = readAddress(in);
 					pos += 4;
@@ -307,11 +307,12 @@ public class HexInputStream extends FilterInputStream {
 						return 0;
 					lastAddress = address << 16;
 					pos += skip(in, 2 /* check sum */);
+					break;
 				}
-				default -> {
+				default:
 					final long toBeSkipped = lineSize * 2L /* 2 hex per one byte */ + 2 /* check sum */;
 					pos += skip(in, toBeSkipped);
-				}
+					break;
 			}
 		} while (type != 0);
 

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/internal/exception/DeviceDisconnectedException.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/internal/exception/DeviceDisconnectedException.java
@@ -22,13 +22,10 @@
 
 package no.nordicsemi.android.dfu.internal.exception;
 
-import java.io.Serial;
-
 /**
  * Device has disconnected.
  */
 public class DeviceDisconnectedException extends Exception {
-	@Serial
 	private static final long serialVersionUID = -6901728550661937942L;
 
 	public DeviceDisconnectedException(final String message) {

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/internal/exception/DfuException.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/internal/exception/DfuException.java
@@ -22,15 +22,12 @@
 
 package no.nordicsemi.android.dfu.internal.exception;
 
-import java.io.Serial;
-
 import no.nordicsemi.android.dfu.DfuBaseService;
 
 /**
  * A DFU error occurred on the remote DFU target.
  */
 public class DfuException extends Exception {
-	@Serial
 	private static final long serialVersionUID = -6901728550661937942L;
 
 	private final int mError;

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/internal/exception/HexFileValidationException.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/internal/exception/HexFileValidationException.java
@@ -23,13 +23,11 @@
 package no.nordicsemi.android.dfu.internal.exception;
 
 import java.io.IOException;
-import java.io.Serial;
 
 /**
  * The HEX file could not be parsed.
  */
 public class HexFileValidationException extends IOException {
-	@Serial
 	private static final long serialVersionUID = -6467104024030837875L;
 
 	public HexFileValidationException(final String message) {

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/internal/exception/RemoteDfuException.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/internal/exception/RemoteDfuException.java
@@ -22,13 +22,10 @@
 
 package no.nordicsemi.android.dfu.internal.exception;
 
-import java.io.Serial;
-
 /**
  * A DFU error occurred on the remote DFU target.
  */
 public class RemoteDfuException extends Exception {
-	@Serial
 	private static final long serialVersionUID = -6901728550661937942L;
 
 	private final int mState;

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/internal/exception/RemoteDfuExtendedErrorException.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/internal/exception/RemoteDfuExtendedErrorException.java
@@ -22,15 +22,12 @@
 
 package no.nordicsemi.android.dfu.internal.exception;
 
-import java.io.Serial;
-
 import no.nordicsemi.android.error.SecureDfuError;
 
 /**
  * A DFU error occurred on the remote DFU target.
  */
 public class RemoteDfuExtendedErrorException extends RemoteDfuException {
-	@Serial
 	private static final long serialVersionUID = -6901728550661937942L;
 
 	private final int mError;

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/internal/exception/SizeValidationException.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/internal/exception/SizeValidationException.java
@@ -23,14 +23,12 @@
 package no.nordicsemi.android.dfu.internal.exception;
 
 import java.io.IOException;
-import java.io.Serial;
 
 /**
  * This exception is thrown when the firmware size is not word-aligned (number of bytes does not divide by 4).
  * This is the requirement for the DFU Bootloader.
  */
 public class SizeValidationException extends IOException {
-	@Serial
 	private static final long serialVersionUID = -6467104024030837875L;
 
 	public SizeValidationException(final String message) {

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/internal/exception/UnknownResponseException.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/internal/exception/UnknownResponseException.java
@@ -22,11 +22,9 @@
 
 package no.nordicsemi.android.dfu.internal.exception;
 
-import java.io.Serial;
 import java.util.Locale;
 
 public class UnknownResponseException extends Exception {
-	@Serial
 	private static final long serialVersionUID = -8716125467309979289L;
 	private static final char[] HEX_ARRAY = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
 

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/internal/exception/UploadAbortedException.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/internal/exception/UploadAbortedException.java
@@ -22,10 +22,7 @@
 
 package no.nordicsemi.android.dfu.internal.exception;
 
-import java.io.Serial;
-
 public class UploadAbortedException extends Exception {
-	@Serial
 	private static final long serialVersionUID = -6901728550661937942L;
 
 	public UploadAbortedException() {

--- a/lib/dfu/src/main/java/no/nordicsemi/android/error/GattError.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/error/GattError.java
@@ -39,18 +39,28 @@ public class GattError {
 	 * @return the error name as stated in the gatt_api.h file
 	 */
 	public static String parseConnectionError(final int error) {
-		return switch (error) {
-			case BluetoothGatt.GATT_SUCCESS -> "SUCCESS";
-			case 0x01 -> "GATT CONN L2C FAILURE";
-			case 0x08 -> "GATT CONN TIMEOUT";
-			case 0x13 -> "GATT CONN TERMINATE PEER USER";
-			case 0x16 -> "GATT CONN TERMINATE LOCAL HOST";
-			case 0x3E -> "GATT CONN FAIL ESTABLISH";
-			case 0x22 -> "GATT CONN LMP TIMEOUT";
-			case 0x0100 -> "GATT CONN CANCEL ";
-			case 0x0085 -> "GATT ERROR"; // Device not reachable
-			default -> "UNKNOWN (" + error + ")";
-		};
+		switch (error) {
+			case BluetoothGatt.GATT_SUCCESS:
+				return "SUCCESS";
+			case 0x01:
+				return "GATT CONN L2C FAILURE";
+			case 0x08:
+				return "GATT CONN TIMEOUT";
+			case 0x13:
+				return "GATT CONN TERMINATE PEER USER";
+			case 0x16:
+				return "GATT CONN TERMINATE LOCAL HOST";
+			case 0x3E:
+				return "GATT CONN FAIL ESTABLISH";
+			case 0x22:
+				return "GATT CONN LMP TIMEOUT";
+			case 0x0100:
+				return "GATT CONN CANCEL ";
+			case 0x0085:
+				return "GATT ERROR"; // Device not reachable
+			default:
+				return "UNKNOWN (" + error + ")";
+		}
 	}
 
 	// Starts at line 29 of the gatt_api.h file
@@ -60,78 +70,138 @@ public class GattError {
 	 * @return the error name as stated in the gatt_api.h file
 	 */
 	public static String parse(final int error) {
-		return switch (error) {
-			case 0x0001 -> "GATT INVALID HANDLE";
-			case 0x0002 -> "GATT READ NOT PERMIT";
-			case 0x0003 -> "GATT WRITE NOT PERMIT";
-			case 0x0004 -> "GATT INVALID PDU";
-			case 0x0005 -> "GATT INSUF AUTHENTICATION";
-			case 0x0006 -> "GATT REQ NOT SUPPORTED";
-			case 0x0007 -> "GATT INVALID OFFSET";
-			case 0x0008 -> "GATT INSUF AUTHORIZATION";
-			case 0x0009 -> "GATT PREPARE Q FULL";
-			case 0x000a -> "GATT NOT FOUND";
-			case 0x000b -> "GATT NOT LONG";
-			case 0x000c -> "GATT INSUF KEY SIZE";
-			case 0x000d -> "GATT INVALID ATTR LEN";
-			case 0x000e -> "GATT ERR UNLIKELY";
-			case 0x000f -> "GATT INSUF ENCRYPTION";
-			case 0x0010 -> "GATT UNSUPPORT GRP TYPE";
-			case 0x0011 -> "GATT INSUF RESOURCE";
-			case 0x001A -> "HCI ERROR UNSUPPORTED REMOTE FEATURE";
-			case 0x001E -> "HCI ERROR INVALID LMP PARAM";
-			case 0x0022 -> "GATT CONN LMP TIMEOUT";
-			case 0x002A -> "HCI ERROR DIFF TRANSACTION COLLISION";
-			case 0x003A -> "GATT CONTROLLER BUSY";
-			case 0x003B -> "GATT UNACCEPT CONN INTERVAL";
-			case 0x0087 -> "GATT ILLEGAL PARAMETER";
-			case 0x0080 -> "GATT NO RESOURCES";
-			case 0x0081 -> "GATT INTERNAL ERROR";
-			case 0x0082 -> "GATT WRONG STATE";
-			case 0x0083 -> "GATT DB FULL";
-			case 0x0084 -> "GATT BUSY";
-			case 0x0085 -> "GATT ERROR";
-			case 0x0086 -> "GATT CMD STARTED";
-			case 0x0088 -> "GATT PENDING";
-			case 0x0089 -> "GATT AUTH FAIL";
-			case 0x008a -> "GATT MORE";
-			case 0x008b -> "GATT INVALID CFG";
-			case 0x008c -> "GATT SERVICE STARTED";
-			case 0x008d -> "GATT ENCRYPTED NO MITM";
-			case 0x008e -> "GATT NOT ENCRYPTED";
-			case 0x008f -> "GATT CONGESTED";
-			case 0x00FD -> "GATT CCCD CFG ERROR";
-			case 0x00FE -> "GATT PROCEDURE IN PROGRESS";
-			case 0x00FF -> "GATT VALUE OUT OF RANGE";
-			case 0x0101 -> "TOO MANY OPEN CONNECTIONS";
-			case DfuBaseService.ERROR_DEVICE_DISCONNECTED -> "DFU DEVICE DISCONNECTED";
-			case DfuBaseService.ERROR_FILE_NOT_FOUND -> "DFU FILE NOT FOUND";
-			case DfuBaseService.ERROR_FILE_ERROR -> "DFU FILE ERROR";
-			case DfuBaseService.ERROR_FILE_INVALID -> "DFU NOT A VALID HEX FILE";
-			case DfuBaseService.ERROR_FILE_IO_EXCEPTION -> "DFU IO EXCEPTION";
-			case DfuBaseService.ERROR_SERVICE_DISCOVERY_NOT_STARTED ->
-					"DFU SERVICE DISCOVERY NOT STARTED";
-			case DfuBaseService.ERROR_SERVICE_NOT_FOUND -> "DFU CHARACTERISTICS NOT FOUND";
-			case DfuBaseService.ERROR_INVALID_RESPONSE -> "DFU INVALID RESPONSE";
-			case DfuBaseService.ERROR_FILE_TYPE_UNSUPPORTED -> "DFU FILE TYPE NOT SUPPORTED";
-			case DfuBaseService.ERROR_BLUETOOTH_DISABLED -> "BLUETOOTH ADAPTER DISABLED";
-			case DfuBaseService.ERROR_INIT_PACKET_REQUIRED -> "DFU INIT PACKET REQUIRED";
-			case DfuBaseService.ERROR_FILE_SIZE_INVALID -> "DFU INIT PACKET REQUIRED";
-			case DfuBaseService.ERROR_CRC_ERROR -> "DFU CRC ERROR";
-			case DfuBaseService.ERROR_DEVICE_NOT_BONDED -> "DFU DEVICE NOT BONDED";
-			default -> "UNKNOWN (" + error + ")";
-		};
+		switch (error) {
+			case 0x0001:
+				return "GATT INVALID HANDLE";
+			case 0x0002:
+				return "GATT READ NOT PERMIT";
+			case 0x0003:
+				return "GATT WRITE NOT PERMIT";
+			case 0x0004:
+				return "GATT INVALID PDU";
+			case 0x0005:
+				return "GATT INSUF AUTHENTICATION";
+			case 0x0006:
+				return "GATT REQ NOT SUPPORTED";
+			case 0x0007:
+				return "GATT INVALID OFFSET";
+			case 0x0008:
+				return "GATT INSUF AUTHORIZATION";
+			case 0x0009:
+				return "GATT PREPARE Q FULL";
+			case 0x000a:
+				return "GATT NOT FOUND";
+			case 0x000b:
+				return "GATT NOT LONG";
+			case 0x000c:
+				return "GATT INSUF KEY SIZE";
+			case 0x000d:
+				return "GATT INVALID ATTR LEN";
+			case 0x000e:
+				return "GATT ERR UNLIKELY";
+			case 0x000f:
+				return "GATT INSUF ENCRYPTION";
+			case 0x0010:
+				return "GATT UNSUPPORT GRP TYPE";
+			case 0x0011:
+				return "GATT INSUF RESOURCE";
+			case 0x001A:
+				return "HCI ERROR UNSUPPORTED REMOTE FEATURE";
+			case 0x001E:
+				return "HCI ERROR INVALID LMP PARAM";
+			case 0x0022:
+				return "GATT CONN LMP TIMEOUT";
+			case 0x002A:
+				return "HCI ERROR DIFF TRANSACTION COLLISION";
+			case 0x003A:
+				return "GATT CONTROLLER BUSY";
+			case 0x003B:
+				return "GATT UNACCEPT CONN INTERVAL";
+			case 0x0087:
+				return "GATT ILLEGAL PARAMETER";
+			case 0x0080:
+				return "GATT NO RESOURCES";
+			case 0x0081:
+				return "GATT INTERNAL ERROR";
+			case 0x0082:
+				return "GATT WRONG STATE";
+			case 0x0083:
+				return "GATT DB FULL";
+			case 0x0084:
+				return "GATT BUSY";
+			case 0x0085:
+				return "GATT ERROR";
+			case 0x0086:
+				return "GATT CMD STARTED";
+			case 0x0088:
+				return "GATT PENDING";
+			case 0x0089:
+				return "GATT AUTH FAIL";
+			case 0x008a:
+				return "GATT MORE";
+			case 0x008b:
+				return "GATT INVALID CFG";
+			case 0x008c:
+				return "GATT SERVICE STARTED";
+			case 0x008d:
+				return "GATT ENCRYPTED NO MITM";
+			case 0x008e:
+				return "GATT NOT ENCRYPTED";
+			case 0x008f:
+				return "GATT CONGESTED";
+			case 0x00FD:
+				return "GATT CCCD CFG ERROR";
+			case 0x00FE:
+				return "GATT PROCEDURE IN PROGRESS";
+			case 0x00FF:
+				return "GATT VALUE OUT OF RANGE";
+			case 0x0101:
+				return "TOO MANY OPEN CONNECTIONS";
+			case DfuBaseService.ERROR_DEVICE_DISCONNECTED:
+				return "DFU DEVICE DISCONNECTED";
+			case DfuBaseService.ERROR_FILE_NOT_FOUND:
+				return "DFU FILE NOT FOUND";
+			case DfuBaseService.ERROR_FILE_ERROR:
+				return "DFU FILE ERROR";
+			case DfuBaseService.ERROR_FILE_INVALID:
+				return "DFU NOT A VALID HEX FILE";
+			case DfuBaseService.ERROR_FILE_IO_EXCEPTION:
+				return "DFU IO EXCEPTION";
+			case DfuBaseService.ERROR_SERVICE_DISCOVERY_NOT_STARTED:
+				return "DFU SERVICE DISCOVERY NOT STARTED";
+			case DfuBaseService.ERROR_SERVICE_NOT_FOUND:
+				return "DFU CHARACTERISTICS NOT FOUND";
+			case DfuBaseService.ERROR_INVALID_RESPONSE:
+				return "DFU INVALID RESPONSE";
+			case DfuBaseService.ERROR_FILE_TYPE_UNSUPPORTED:
+				return "DFU FILE TYPE NOT SUPPORTED";
+			case DfuBaseService.ERROR_BLUETOOTH_DISABLED:
+				return "BLUETOOTH ADAPTER DISABLED";
+			case DfuBaseService.ERROR_INIT_PACKET_REQUIRED:
+				return "DFU INIT PACKET REQUIRED";
+			case DfuBaseService.ERROR_FILE_SIZE_INVALID:
+				return "DFU INIT PACKET REQUIRED";
+			case DfuBaseService.ERROR_CRC_ERROR:
+				return "DFU CRC ERROR";
+			case DfuBaseService.ERROR_DEVICE_NOT_BONDED:
+				return "DFU DEVICE NOT BONDED";
+			default:
+				return "UNKNOWN (" + error + ")";
+		}
 	}
 
 	public static String parseDfuRemoteError(final int error) {
-		return switch (error & (DfuBaseService.ERROR_REMOTE_TYPE_LEGACY | DfuBaseService.ERROR_REMOTE_TYPE_SECURE | DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | DfuBaseService.ERROR_REMOTE_TYPE_SECURE_BUTTONLESS)) {
-			case DfuBaseService.ERROR_REMOTE_TYPE_LEGACY -> LegacyDfuError.parse(error);
-			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE -> SecureDfuError.parse(error);
-			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED ->
-					SecureDfuError.parseExtendedError(error);
-			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_BUTTONLESS ->
-					SecureDfuError.parseButtonlessError(error);
-			default -> "UNKNOWN (" + error + ")";
-		};
+		switch (error & (DfuBaseService.ERROR_REMOTE_TYPE_LEGACY | DfuBaseService.ERROR_REMOTE_TYPE_SECURE | DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | DfuBaseService.ERROR_REMOTE_TYPE_SECURE_BUTTONLESS)) {
+			case DfuBaseService.ERROR_REMOTE_TYPE_LEGACY:
+				return LegacyDfuError.parse(error);
+			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE:
+				return SecureDfuError.parse(error);
+			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED:
+				return SecureDfuError.parseExtendedError(error);
+			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_BUTTONLESS:
+				return SecureDfuError.parseButtonlessError(error);
+			default:
+				return "UNKNOWN (" + error + ")";
+		}
 	}
 }

--- a/lib/dfu/src/main/java/no/nordicsemi/android/error/LegacyDfuError.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/error/LegacyDfuError.java
@@ -34,14 +34,14 @@ public final class LegacyDfuError {
 	public static final int OPERATION_FAILED = 6;
 
 	public static String parse(final int error) {
-		return switch (error) {
-			case DfuBaseService.ERROR_REMOTE_TYPE_LEGACY | INVALID_STATE -> "INVALID STATE";
-			case DfuBaseService.ERROR_REMOTE_TYPE_LEGACY | NOT_SUPPORTED -> "NOT SUPPORTED";
-			case DfuBaseService.ERROR_REMOTE_TYPE_LEGACY | DATA_SIZE_EXCEEDS_LIMIT ->
-					"DATA SIZE EXCEEDS LIMIT";
-			case DfuBaseService.ERROR_REMOTE_TYPE_LEGACY | CRC_ERROR -> "INVALID CRC ERROR";
-			case DfuBaseService.ERROR_REMOTE_TYPE_LEGACY | OPERATION_FAILED -> "OPERATION FAILED";
-			default -> "UNKNOWN (" + error + ")";
-		};
+		switch (error) {
+			case DfuBaseService.ERROR_REMOTE_TYPE_LEGACY | INVALID_STATE:				return "INVALID STATE";
+			case DfuBaseService.ERROR_REMOTE_TYPE_LEGACY | NOT_SUPPORTED:				return "NOT SUPPORTED";
+			case DfuBaseService.ERROR_REMOTE_TYPE_LEGACY | DATA_SIZE_EXCEEDS_LIMIT:		return "DATA SIZE EXCEEDS LIMIT";
+			case DfuBaseService.ERROR_REMOTE_TYPE_LEGACY | CRC_ERROR:					return "INVALID CRC ERROR";
+			case DfuBaseService.ERROR_REMOTE_TYPE_LEGACY | OPERATION_FAILED:			return "OPERATION FAILED";
+			default:
+				return "UNKNOWN (" + error + ")";
+		}
 	}
 }

--- a/lib/dfu/src/main/java/no/nordicsemi/android/error/SecureDfuError.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/error/SecureDfuError.java
@@ -55,59 +55,45 @@ public final class SecureDfuError {
 	public static final int BUTTONLESS_ERROR_OPERATION_FAILED = 4;
 
 	public static String parse(final int error) {
-		return switch (error) {
-			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE | OP_CODE_NOT_SUPPORTED ->
-					"OP CODE NOT SUPPORTED";
-			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE | INVALID_PARAM -> "INVALID PARAM";
-			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE | INSUFFICIENT_RESOURCES ->
-					"INSUFFICIENT RESOURCES";
-			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE | INVALID_OBJECT -> "INVALID OBJECT";
-			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE | UNSUPPORTED_TYPE -> "UNSUPPORTED TYPE";
-			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE | OPERATION_NOT_PERMITTED ->
-					"OPERATION NOT PERMITTED";
-			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE | OPERATION_FAILED -> "OPERATION FAILED";
-			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE | EXTENDED_ERROR -> "EXTENDED ERROR";
-			default -> "UNKNOWN (" + error + ")";
-		};
+		switch (error) {
+			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE | OP_CODE_NOT_SUPPORTED:		return "OP CODE NOT SUPPORTED";
+			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE | INVALID_PARAM:				return "INVALID PARAM";
+			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE | INSUFFICIENT_RESOURCES:		return "INSUFFICIENT RESOURCES";
+			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE | INVALID_OBJECT:				return "INVALID OBJECT";
+			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE | UNSUPPORTED_TYPE:			return "UNSUPPORTED TYPE";
+			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE | OPERATION_NOT_PERMITTED:		return "OPERATION NOT PERMITTED";
+			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE | OPERATION_FAILED:			return "OPERATION FAILED";
+			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE | EXTENDED_ERROR:				return "EXTENDED ERROR";
+			default:
+				return "UNKNOWN (" + error + ")";
+		}
 	}
 
 	public static String parseExtendedError(final int error) {
-		return switch (error) {
-			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | EXT_ERROR_WRONG_COMMAND_FORMAT ->
-					"Wrong command format";
-			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | EXT_ERROR_UNKNOWN_COMMAND ->
-					"Unknown command";
-			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | EXT_ERROR_INIT_COMMAND_INVALID ->
-					"Init command invalid";
-			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | EXT_ERROR_FW_VERSION_FAILURE ->
-					"FW version failure";
-			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | EXT_ERROR_HW_VERSION_FAILURE ->
-					"HW version failure";
-			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | EXT_ERROR_SD_VERSION_FAILURE ->
-					"SD version failure";
-			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | EXT_ERROR_SIGNATURE_MISSING ->
-					"Signature mismatch";
-			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | EXT_ERROR_WRONG_HASH_TYPE ->
-					"Wrong hash type";
-			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | EXT_ERROR_HASH_FAILED ->
-					"Hash failed";
-			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | EXT_ERROR_WRONG_SIGNATURE_TYPE ->
-					"Wrong signature type";
-			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | EXT_ERROR_VERIFICATION_FAILED ->
-					"Verification failed";
-			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | EXT_ERROR_INSUFFICIENT_SPACE ->
-					"Insufficient space";
-			default -> "Reserved for future use";
-		};
+		switch (error) {
+			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | EXT_ERROR_WRONG_COMMAND_FORMAT: return "Wrong command format";
+			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | EXT_ERROR_UNKNOWN_COMMAND:		return "Unknown command";
+			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | EXT_ERROR_INIT_COMMAND_INVALID: return "Init command invalid";
+			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | EXT_ERROR_FW_VERSION_FAILURE:	return "FW version failure";
+			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | EXT_ERROR_HW_VERSION_FAILURE:	return "HW version failure";
+			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | EXT_ERROR_SD_VERSION_FAILURE:	return "SD version failure";
+			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | EXT_ERROR_SIGNATURE_MISSING :	return "Signature mismatch";
+			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | EXT_ERROR_WRONG_HASH_TYPE:		return "Wrong hash type";
+			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | EXT_ERROR_HASH_FAILED:			return "Hash failed";
+			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | EXT_ERROR_WRONG_SIGNATURE_TYPE: return "Wrong signature type";
+			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | EXT_ERROR_VERIFICATION_FAILED:	return "Verification failed";
+			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_EXTENDED | EXT_ERROR_INSUFFICIENT_SPACE:	return "Insufficient space";
+			default:
+				return "Reserved for future use";
+		}
 	}
 
 	public static String parseButtonlessError(final int error) {
-		return switch (error) {
-			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_BUTTONLESS | BUTTONLESS_ERROR_OP_CODE_NOT_SUPPORTED ->
-					"OP CODE NOT SUPPORTED";
-			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_BUTTONLESS | BUTTONLESS_ERROR_OPERATION_FAILED ->
-					"OPERATION FAILED";
-			default -> "UNKNOWN (" + error + ")";
-		};
+		switch (error) {
+			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_BUTTONLESS | BUTTONLESS_ERROR_OP_CODE_NOT_SUPPORTED:	return "OP CODE NOT SUPPORTED";
+			case DfuBaseService.ERROR_REMOTE_TYPE_SECURE_BUTTONLESS | BUTTONLESS_ERROR_OPERATION_FAILED:		return "OPERATION FAILED";
+			default:
+				return "UNKNOWN (" + error + ")";
+		}
 	}
 }


### PR DESCRIPTION
This PR fixes #411.
All Java 17 code was migrated back to Java 11 to make the lib compatible with Unity. 