### PR TITLE
Deep links fixed

### DIFF
--- a/lib/storage/src/main/java/no/nordicsemi/android/dfu/storage/ExternalFileDataSource.kt
+++ b/lib/storage/src/main/java/no/nordicsemi/android/dfu/storage/ExternalFileDataSource.kt
@@ -75,7 +75,7 @@ class ExternalFileDataSource @Inject internal constructor(
         ContextCompat.registerReceiver(context,
             onDownloadCompleteReceiver,
             IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
-            ContextCompat.RECEIVER_NOT_EXPORTED
+            ContextCompat.RECEIVER_EXPORTED
         )
     }
 


### PR DESCRIPTION
This PR fixes a bug causing deep links not to work.
The `DownloadManager` reports completion using a broadcast, but the received was registered as not exported. 
The event was never received by the app.