### PR TITLE
Version catalog updated to 1.10.4

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("no.nordicsemi.android.gradle:version-catalog:1.9.17")
+            from("no.nordicsemi.android.gradle:version-catalog:1.10.4")
         }
     }
 }


### PR DESCRIPTION
This PR migrates the app to Nordic version catalog [1.10.4](https://github.com/NordicSemiconductor/Android-Gradle-Plugins/releases/tag/1.10.4).
Among others, the change includes Gradle Wrapper 8.2.0 and Compose Material 3 version 1.2.0-beta01.