### PR TITLE
Foreground service behavior fixed

### DIFF
--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/BaseDfuImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/BaseDfuImpl.java
@@ -831,7 +831,11 @@ import no.nordicsemi.android.dfu.internal.scanner.BootloaderScannerFactory;
 		// Reset the DFU attempt counter
 		intent.putExtra(DfuBaseService.EXTRA_DFU_ATTEMPT, 0);
 
-		mService.startService(intent);
+		final boolean foregroundService = intent.getBooleanExtra(DfuBaseService.EXTRA_FOREGROUND_SERVICE, true);
+		if (foregroundService && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+			mService.startForegroundService(intent);
+		else
+			mService.startService(intent);
 	}
 
 	protected String parse(@Nullable final byte[] data) {

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -1922,7 +1922,12 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 		// Any additional configuration?
 		updateForegroundNotification(builder);
 
-		startForeground(NOTIFICATION_ID, builder.build());
+		try {
+			startForeground(NOTIFICATION_ID, builder.build());
+		} catch (final SecurityException e) {
+			loge("Service cannot be started in foreground", e);
+			logi("Starting DFU service in background instead");
+		}
 	}
 
 	/**

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -1356,7 +1356,11 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 					final Intent newIntent = new Intent();
 					newIntent.fillIn(intent, Intent.FILL_IN_COMPONENT | Intent.FILL_IN_PACKAGE);
 					newIntent.putExtra(EXTRA_RECONNECTION_ATTEMPT, attempt + 1);
-					startService(newIntent);
+
+					if (foregroundService && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+						startForegroundService(newIntent);
+					else
+						startService(newIntent);
 					return;
 				}
 				terminateConnection(gatt, mError);
@@ -1415,7 +1419,11 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 					final Intent newIntent = new Intent();
 					newIntent.fillIn(intent, Intent.FILL_IN_COMPONENT | Intent.FILL_IN_PACKAGE);
 					newIntent.putExtra(EXTRA_DFU_ATTEMPT, attempt + 1);
-					startService(newIntent);
+
+					if (foregroundService && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+						startForegroundService(newIntent);
+					else
+						startService(newIntent);
 					return;
 				}
 				report(ERROR_DEVICE_DISCONNECTED);


### PR DESCRIPTION
This PR fixes the following issues:
- when restarted with `EXTRA_FOREGROUND_SERVICE` flag set to *true*, the service will be started using `startForegroundService(Intent)` instead of `startService(Intent)`
- when `startForeground(int, Notification)` crashes due to security exception (app is in background and the service cannot be started in foreground) the error is logged and ignored. As DFU is not very long task, the app update should succeed nevertheless.