### PR TITLE
Use positional format specifier for uploading resource

### DIFF
--- a/lib/dfu/src/main/res/values/strings.xml
+++ b/lib/dfu/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
     <string name="dfu_status_starting">Starting DFU&#8230;</string>
     <string name="dfu_status_switching_to_dfu">Starting bootloader&#8230;</string>
     <string name="dfu_status_uploading">Uploading&#8230;</string>
-    <string name="dfu_status_uploading_part">Uploading part %d/%d&#8230;</string>
+    <string name="dfu_status_uploading_part">Uploading part %1$d/%2$d&#8230;</string>
     <string name="dfu_status_validating">Validating&#8230;</string>
     <string name="dfu_status_disconnecting">Disconnecting&#8230;</string>
     <string name="dfu_status_completed">Done</string>


### PR DESCRIPTION
This PR fixes the following issue:

- When creating bindings of the latest version for a MAUI application, the build fails with the following error. By using positional format specifiers for the string resource with two format specifiers, it worked for me.

```
values.xml(2): Error APT2000 : multiple substitutions specified in non-positional format; did you mean to add the formatted="false" attribute?.
values.xml: Error APT2261 : file failed to compile.
```

Fixes #428 