### PR TITLE
Fixed scanning with screen off

### DIFF
--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/BaseButtonlessDfuImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/BaseButtonlessDfuImpl.java
@@ -94,6 +94,6 @@ import androidx.annotation.NonNull;
 		logi("Restarting to bootloader mode");
 		final Intent newIntent = new Intent();
 		newIntent.fillIn(intent, Intent.FILL_IN_COMPONENT | Intent.FILL_IN_PACKAGE);
-		restartService(newIntent, scanForBootloader);
+		restartService(newIntent, scanForBootloader, getDfuServiceUUID());
 	}
 }

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/BaseCustomDfuImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/BaseCustomDfuImpl.java
@@ -280,8 +280,6 @@ import no.nordicsemi.android.dfu.internal.exception.UploadAbortedException;
 
 	protected abstract UUID getPacketCharacteristicUUID();
 
-	protected abstract UUID getDfuServiceUUID();
-
 	/**
 	 * Sends the whole init packet stream to the given characteristic.
 	 *
@@ -510,10 +508,10 @@ import no.nordicsemi.android.dfu.internal.exception.UploadAbortedException;
 			 * when the new Soft Device was uploaded and the old application has been removed in
 			 * this process.
 			 *
-			 * We could have save the fact of jumping as a parameter of the service but it ma be
-			 * that some Android devices must first scan a device before connecting to it.
-			 * It a device with the address+1 has never been detected before the service could have
-			 * failed on connection.
+			 * We could have save the fact of jumping as a parameter of the service but Android
+			 * devices must first scan a device before connecting to it to get the address type.
+			 * If a device with the address+1 has never been detected before the service could have
+			 * failed on connection as it would be trying to connect to a public address.
 			 */
 
 			/*
@@ -527,7 +525,7 @@ import no.nordicsemi.android.dfu.internal.exception.UploadAbortedException;
 			newIntent.putExtra(DfuBaseService.EXTRA_FILE_TYPE, DfuBaseService.TYPE_APPLICATION); // set the type to application only
 			newIntent.putExtra(DfuBaseService.EXTRA_PART_CURRENT, mProgressInfo.getCurrentPart() + 1);
 			newIntent.putExtra(DfuBaseService.EXTRA_PARTS_TOTAL, mProgressInfo.getTotalParts());
-			restartService(newIntent, /* the bootloader may advertise with different address */ true);
+			restartService(newIntent, /* the bootloader may advertise with different address */ true, getDfuServiceUUID());
 		}
 	}
 }

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/BaseDfuImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/BaseDfuImpl.java
@@ -808,7 +808,7 @@ import no.nordicsemi.android.dfu.internal.scanner.BootloaderScannerFactory;
 	 * @param intent            the intent to be started as a service
 	 * @param scanForBootloader true to scan for advertising bootloader, false to keep the same address
 	 */
-	void restartService(@NonNull final Intent intent, final boolean scanForBootloader) {
+	void restartService(@NonNull final Intent intent, final boolean scanForBootloader, @NonNull final UUID serviceUuid) {
 		String newAddress = null;
 		if (scanForBootloader) {
 			final long delay = intent.getLongExtra(DfuBaseService.EXTRA_SCAN_DELAY, 0);
@@ -816,7 +816,10 @@ import no.nordicsemi.android.dfu.internal.scanner.BootloaderScannerFactory;
 			mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_VERBOSE, "Scanning for the DFU Bootloader... (timeout " + timeout + " ms)");
 			if (delay > 0)
 				mService.waitFor(delay);
-			newAddress = BootloaderScannerFactory.getScanner(mGatt.getDevice().getAddress()).searchUsing(mService.getDeviceSelector(), timeout);
+			logi("Scanning for the DFU Bootloader... (timeout " + timeout + " ms)");
+			newAddress = BootloaderScannerFactory
+					.getScanner(mGatt.getDevice().getAddress(), serviceUuid)
+					.searchUsing(mService.getDeviceSelector(), timeout);
 			logi("Scanning for new address finished with: " + newAddress);
 			if (newAddress != null)
 				mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_INFO, "DFU Bootloader found with address " + newAddress);
@@ -837,6 +840,13 @@ import no.nordicsemi.android.dfu.internal.scanner.BootloaderScannerFactory;
 		else
 			mService.startService(intent);
 	}
+
+	/**
+	 * Returns the service UUID used by the DFU target.
+	 * @return the service UUID.
+	 */
+	@NonNull
+	protected abstract UUID getDfuServiceUUID();
 
 	protected String parse(@Nullable final byte[] data) {
 		if (data == null)

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/ButtonlessDfuWithBondSharingImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/ButtonlessDfuWithBondSharingImpl.java
@@ -83,6 +83,12 @@ import no.nordicsemi.android.dfu.internal.exception.UploadAbortedException;
 		return mButtonlessDfuCharacteristic;
 	}
 
+	@NonNull
+	@Override
+	protected UUID getDfuServiceUUID() {
+		return SecureDfuImpl.DFU_SERVICE_UUID;
+	}
+
 	@Override
 	protected boolean shouldScanForBootloader() {
 		return false;

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/ButtonlessDfuWithoutBondSharingImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/ButtonlessDfuWithoutBondSharingImpl.java
@@ -90,6 +90,12 @@ import no.nordicsemi.android.dfu.internal.exception.UploadAbortedException;
 		return mButtonlessDfuCharacteristic;
 	}
 
+	@NonNull
+    @Override
+	protected UUID getDfuServiceUUID() {
+		return SecureDfuImpl.DFU_SERVICE_UUID;
+	}
+
 	@Override
 	protected boolean shouldScanForBootloader() {
 		return true;

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuDeviceSelector.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuDeviceSelector.java
@@ -10,7 +10,6 @@ import androidx.annotation.RequiresApi;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 /**
  * The device selector can be used to filter scan results when scanning for the device

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/ExperimentalButtonlessDfuImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/ExperimentalButtonlessDfuImpl.java
@@ -77,6 +77,12 @@ import no.nordicsemi.android.dfu.internal.exception.UploadAbortedException;
 		return mButtonlessDfuCharacteristic;
 	}
 
+	@NonNull
+	@Override
+	protected UUID getDfuServiceUUID() {
+		return SecureDfuImpl.DFU_SERVICE_UUID;
+	}
+
 	@Override
 	protected boolean shouldScanForBootloader() {
 		return true;

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyButtonlessDfuImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyButtonlessDfuImpl.java
@@ -59,6 +59,12 @@ import no.nordicsemi.android.dfu.internal.exception.UploadAbortedException;
 		super(intent, service);
 	}
 
+	@NonNull
+	@Override
+	protected UUID getDfuServiceUUID() {
+		return LegacyDfuImpl.DFU_SERVICE_UUID;
+	}
+
 	@SuppressWarnings("deprecation")
 	@Override
 	public boolean isClientCompatible(@NonNull final Intent intent, @NonNull final BluetoothGatt gatt)

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyDfuImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyDfuImpl.java
@@ -159,6 +159,7 @@ import no.nordicsemi.android.error.LegacyDfuError;
 		return DFU_PACKET_UUID;
 	}
 
+	@NonNull
 	@Override
 	protected UUID getDfuServiceUUID() {
 		return DFU_SERVICE_UUID;
@@ -763,6 +764,6 @@ import no.nordicsemi.android.error.LegacyDfuError;
 		logi("Restarting the service");
 		final Intent newIntent = new Intent();
 		newIntent.fillIn(intent, Intent.FILL_IN_COMPONENT | Intent.FILL_IN_PACKAGE);
-		restartService(newIntent, false);
+		restartService(newIntent, false, DFU_SERVICE_UUID);
 	}
 }

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/SecureDfuImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/SecureDfuImpl.java
@@ -200,6 +200,7 @@ class SecureDfuImpl extends BaseCustomDfuImpl {
 		return DFU_PACKET_UUID;
 	}
 
+	@NonNull
 	@Override
 	protected UUID getDfuServiceUUID() {
 		return DFU_SERVICE_UUID;

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/internal/scanner/BootloaderScannerFactory.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/internal/scanner/BootloaderScannerFactory.java
@@ -25,6 +25,7 @@ package no.nordicsemi.android.dfu.internal.scanner;
 import android.os.Build;
 
 import java.util.Locale;
+import java.util.UUID;
 
 import androidx.annotation.NonNull;
 
@@ -53,11 +54,12 @@ public final class BootloaderScannerFactory {
 	 *
 	 * @return the bootloader scanner
 	 */
-	public static BootloaderScanner getScanner(@NonNull final String deviceAddress) {
+	public static BootloaderScanner getScanner(@NonNull final String deviceAddress,
+											   @NonNull final UUID serviceUuid) {
 		final String deviceAddressIncremented = getIncrementedAddress(deviceAddress);
 
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-			return new BootloaderScannerLollipop(deviceAddress, deviceAddressIncremented);
+			return new BootloaderScannerLollipop(deviceAddress, deviceAddressIncremented, serviceUuid);
 		return new BootloaderScannerJB(deviceAddress, deviceAddressIncremented);
 	}
 }

--- a/lib/settings/src/main/java/no/nordicsemi/android/dfu/settings/domain/DFUSettings.kt
+++ b/lib/settings/src/main/java/no/nordicsemi/android/dfu/settings/domain/DFUSettings.kt
@@ -45,7 +45,7 @@ data class DFUSettings(
     val disableResume: Boolean = false,
     val prepareDataObjectDelay: Int = 400, // ms
     val rebootTime: Int = 0, // ms
-    val scanTimeout: Int = 2_000, // ms
+    val scanTimeout: Int = 6_000, // ms
     val mtuRequestEnabled: Boolean = false,
     val forceScanningInLegacyDfu: Boolean = false,
     val showWelcomeScreen: Boolean = true


### PR DESCRIPTION
This PR fixes #453.

This PR introduces non-empty scan filters for Android 8 and above and an option to customize it from the app.
Override `getDeviceSelector()` method in your `DfuService` implementation to specify custom filters.

The UUID is passed to new `getScanFilters(...)` method in `DfuDeviceSelector`.
By default, the selector will filter for Service UUID with the currently used DFU Service UUID:
* Legacy DFU UUID
* Secure DFU UUID
* Custom UUID if `UuidHelper` was used to modify it.

Using non-empty filters should fix the issue where no devices were found when the app is in background.