### PR TITLE
Bug fix: clearing state causes issues with "Don't keep activities" enabled

### DIFF
--- a/profile/main/src/main/java/no/nordicsemi/android/dfu/profile/main/viewmodel/DFUViewModel.kt
+++ b/profile/main/src/main/java/no/nordicsemi/android/dfu/profile/main/viewmodel/DFUViewModel.kt
@@ -54,10 +54,6 @@ import javax.inject.Singleton
 @Singleton
 internal class StateHolder @Inject constructor() {
     internal val state = MutableStateFlow(DFUViewState())
-
-    fun clear() {
-        state.value = DFUViewState()
-    }
 }
 
 @HiltViewModel
@@ -217,7 +213,6 @@ internal class DFUViewModel @Inject constructor(
         super.onCleared()
 
         if (!repository.isRunning()) {
-            stateHolder.clear()
             repository.release()
         }
     }


### PR DESCRIPTION
This PR fixes an issue with file selection with _Don't keep Activities_ option enabled in Developer Settings.

When the app transitions to a File browser the system kills the nRF DFU app and calles `onCleared()` on the View Model.
If a file was not selected, this was working fine. When restoring the Activity, the file was delivered. However, if the user wanted to change the file to another one, clearing the view model was also changing the view to _file not selected_ after the request was made, so the handler awaiting file was removed. This caused an issue where every second file selection worked, and every second was just clearing the view.

Removing clearing the view state fixes the issue.