### PR TITLE
Migration to `targetSdk` 35

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Sep 10 11:03:46 CEST 2024
+#Mon Oct 21 09:30:25 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("no.nordicsemi.android.gradle:version-catalog:2.4-1")
+            from("no.nordicsemi.android.gradle:version-catalog:2.5")
         }
     }
 }


### PR DESCRIPTION
This PR updates the Android Gradle Plugin dependency from 2.4-1 to 2.5 ([release notes](https://github.com/NordicSemiconductor/Android-Gradle-Plugins/releases/tag/2.5)), which, besides updating various dependencies, sets the `compileSdk` and `targetSdk` to API 35 (Android 15).