### PR TITLE
Bug fix: Reverting `minSdk` to 18

### DIFF
--- a/lib/dfu/build.gradle.kts
+++ b/lib/dfu/build.gradle.kts
@@ -67,7 +67,8 @@ android {
 }
 
 dependencies {
-    implementation(libs.androidx.core)
+    //noinspection GradleDependency
+    implementation("androidx.core:core:1.12.0") // Don't update: 1.13 increases minSdk to 19.
     implementation(libs.androidx.annotation)
     implementation(libs.androidx.localbroadcastmanager)
 


### PR DESCRIPTION
This PR fixes a dependency issue. 
`androidx.core:core:1.13`, which is available in Nordic Android Gradle Plugin 2.5, increases the version to 1.13.1, which sets the `minSdk` to 19. The library should be available from SDK 18 (Android 4.3).
Setting the version to 1.12 does not break any functionality and fixes the issue.