### PR TITLE
DFU speed improved on bonded devices

### DIFF
--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/SecureDfuImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/SecureDfuImpl.java
@@ -244,8 +244,9 @@ class SecureDfuImpl extends BaseCustomDfuImpl {
 
 			final boolean allowResume = !intent.hasExtra(DfuBaseService.EXTRA_DISABLE_RESUME)
 					|| !intent.getBooleanExtra(DfuBaseService.EXTRA_DISABLE_RESUME, false);
-			if (!allowResume)
+			if (!allowResume) {
 				logi("Resume feature disabled. Performing fresh DFU");
+			}
 			try {
 				sendInitPacket(gatt, allowResume);
 			} catch (final RemoteDfuException e) {

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/SecureDfuImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/SecureDfuImpl.java
@@ -230,6 +230,18 @@ class SecureDfuImpl extends BaseCustomDfuImpl {
 			mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_APPLICATION,
                     "Notifications enabled");
 
+			// Request short connection interval.
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+				logi("Requesting high connection priority");
+				mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_VERBOSE,
+						"Requesting high connection priority...");
+				mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_DEBUG,
+						"gatt.requestConnectionPriority(CONNECTION_PRIORITY_HIGH)");
+				mGatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_HIGH);
+				// There will be a (hidden) callback on newer Android versions,
+				// but we don't have to wait for it.
+			}
+
 			final boolean allowResume = !intent.hasExtra(DfuBaseService.EXTRA_DISABLE_RESUME)
 					|| !intent.getBooleanExtra(DfuBaseService.EXTRA_DISABLE_RESUME, false);
 			if (!allowResume)


### PR DESCRIPTION
Android 15 extends connection interval on bonded devices to ~190 ms.
This is significantly longer that on previous versions, where it was kept set to 15 ms.

This PR requests high connection priority, which effectively means requesting short connection interval from the Android side. The upload speed increases in effect from 0.9 to 9.1 kb/s.

This PR fixes #459. 