### PR TITLE
Prioritizing DFU speed in settings

### DIFF
--- a/lib/settings/src/main/java/no/nordicsemi/android/dfu/settings/domain/DFUSettings.kt
+++ b/lib/settings/src/main/java/no/nordicsemi/android/dfu/settings/domain/DFUSettings.kt
@@ -43,10 +43,10 @@ data class DFUSettings(
     val keepBondInformation: Boolean = false,
     val externalMcuDfu: Boolean = false,
     val disableResume: Boolean = false,
-    val prepareDataObjectDelay: Int = 400, // ms
+    val prepareDataObjectDelay: Int = 0, // ms
     val rebootTime: Int = 0, // ms
     val scanTimeout: Int = 6_000, // ms
-    val mtuRequestEnabled: Boolean = false,
+    val mtuRequestEnabled: Boolean = true,
     val forceScanningInLegacyDfu: Boolean = false,
     val showWelcomeScreen: Boolean = true
 ) : Parcelable


### PR DESCRIPTION
This PR modifies the default DFU parameters:
* Sets "Prepare Data Object Delay" to 0 ms (from 400 ms)
* Enables MTU request (was disabled by default)

The goal is to make the DFU faster (reach ~ 9kB/s) on most moden devices.

---
### What are those settings?

1. In Secure DFU the firmware is sent in chunks (4096 bytes each). Each chunk is validated (Calculate CRC) and executed after sending. Executing it saves teh received data in permanent storage on the device. Some implementations of DFU bootloader notify readiness after executing too soon, before the data is actually saved. Prepare _Data Object_ delay is a special delay added after receiving Execute response to give the device some time to finish flash operation. I don't think it's needed with nRF5 SDK 17.1.
Read more here:
https://github.com/NordicSemiconductor/Android-DFU-Library/blob/e2c8028db5d55f92fe342b86e580de1d5e5e87a9/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuServiceInitiator.java#L197-L219

2. Secure DFU from nRF5 SDK 15+ supports MTU (Maximum Transfer Unit) higher than default (23 bytes). With higher MTU more data can be sent in a unit of time. However, some devices, like Samsung Tab A8 and perhaps other with the same hardware claim support for it, but in fact they have a bug preventing use of it. The library will automatically disable MTU for devices with `Build.HARDWARE` set to `ums512_25c10` (see #408), but perhaps there are other devices with similar problem. If you get error 133 just after sending the upload, try disabling MTU request in app's Settings.