### PR TITLE
Various improvements

### DIFF
--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/BaseCustomDfuImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/BaseCustomDfuImpl.java
@@ -354,7 +354,7 @@ import no.nordicsemi.android.dfu.internal.exception.UploadAbortedException;
 			loge("Sleeping interrupted", e);
 		}
 		if (!mConnected)
-			throw new DeviceDisconnectedException("Unable to write Init DFU Parameters: device disconnected");
+			throw new DeviceDisconnectedException("Unable to write Init DFU Parameters: device disconnected", mError);
 		if (mError != 0)
 			throw new DfuException("Unable to write Init DFU Parameters", mError);
 	}
@@ -404,7 +404,7 @@ import no.nordicsemi.android.dfu.internal.exception.UploadAbortedException;
 		}
 
 		if (!mConnected)
-			throw new DeviceDisconnectedException("Uploading Firmware Image failed: device disconnected");
+			throw new DeviceDisconnectedException("Uploading Firmware Image failed: device disconnected", mError);
 		if (mError != 0)
 			throw new DfuException("Uploading Firmware Image failed", mError);
 	}

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/BaseDfuImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/BaseDfuImpl.java
@@ -120,8 +120,9 @@ import no.nordicsemi.android.dfu.internal.scanner.BootloaderScannerFactory;
 		// public void onConnected() { }
 
 		@Override
-		public void onDisconnected() {
+		public void onDisconnected(int error) {
 			mConnected = false;
+			mError = error;
 			notifyLock();
 		}
 
@@ -452,7 +453,7 @@ import no.nordicsemi.android.dfu.internal.scanner.BootloaderScannerFactory;
 		final BluetoothGatt gatt = mGatt;
 		final String debugString = type == NOTIFICATIONS ? "notifications" : "indications";
 		if (!mConnected)
-			throw new DeviceDisconnectedException("Unable to set " + debugString + " state: device disconnected");
+			throw new DeviceDisconnectedException("Unable to set " + debugString + " state: device disconnected", mError);
 		if (mAborted)
 			throw new UploadAbortedException();
 
@@ -491,7 +492,7 @@ import no.nordicsemi.android.dfu.internal.scanner.BootloaderScannerFactory;
 			loge("Sleeping interrupted", e);
 		}
 		if (!mConnected)
-			throw new DeviceDisconnectedException("Unable to set " + debugString + " state: device disconnected");
+			throw new DeviceDisconnectedException("Unable to set " + debugString + " state: device disconnected", mError);
 		if (mError != 0)
 			throw new DfuException("Unable to set " + debugString + " state", mError);
 	}
@@ -508,7 +509,7 @@ import no.nordicsemi.android.dfu.internal.scanner.BootloaderScannerFactory;
 	private boolean isServiceChangedCCCDEnabled()
             throws DeviceDisconnectedException, DfuException, UploadAbortedException {
 		if (!mConnected)
-			throw new DeviceDisconnectedException("Unable to read Service Changed CCCD: device disconnected");
+			throw new DeviceDisconnectedException("Unable to read Service Changed CCCD: device disconnected", mError);
 		if (mAborted)
 			throw new UploadAbortedException();
 
@@ -545,7 +546,7 @@ import no.nordicsemi.android.dfu.internal.scanner.BootloaderScannerFactory;
 			loge("Sleeping interrupted", e);
 		}
 		if (!mConnected)
-			throw new DeviceDisconnectedException("Unable to read Service Changed CCCD: device disconnected");
+			throw new DeviceDisconnectedException("Unable to read Service Changed CCCD: device disconnected", mError);
 		if (mError != 0)
 			throw new DfuException("Unable to read Service Changed CCCD", mError);
 
@@ -608,7 +609,7 @@ import no.nordicsemi.android.dfu.internal.scanner.BootloaderScannerFactory;
 			loge("Sleeping interrupted", e);
 		}
 		if (!mResetRequestSent && !mConnected)
-			throw new DeviceDisconnectedException("Unable to write Op Code " + value[0] + ": device disconnected");
+			throw new DeviceDisconnectedException("Unable to write Op Code " + value[0] + ": device disconnected", mError);
 		if (!mResetRequestSent && mError != 0)
 			throw new DfuException("Unable to write Op Code " + value[0], mError);
 	}
@@ -768,7 +769,7 @@ import no.nordicsemi.android.dfu.internal.scanner.BootloaderScannerFactory;
 			loge("Sleeping interrupted", e);
 		}
 		if (!mConnected)
-			throw new DeviceDisconnectedException("Unable to read Service Changed CCCD: device disconnected");
+			throw new DeviceDisconnectedException("Unable to request MTU: device disconnected", mError);
 	}
 
 	/**
@@ -796,9 +797,9 @@ import no.nordicsemi.android.dfu.internal.scanner.BootloaderScannerFactory;
 		if (mAborted)
 			throw new UploadAbortedException();
 		if (!mConnected)
-			throw new DeviceDisconnectedException("Unable to write Op Code: device disconnected");
+			throw new DeviceDisconnectedException("Response not received: device disconnected", mError);
 		if (mError != 0)
-			throw new DfuException("Unable to write Op Code", mError);
+			throw new DfuException("Response not received", mError);
 		return mReceivedData;
 	}
 

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/BaseDfuImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/BaseDfuImpl.java
@@ -663,7 +663,7 @@ import no.nordicsemi.android.dfu.internal.scanner.BootloaderScannerFactory;
 			//noinspection ConstantConditions
 			return (Boolean) createBond.invoke(device);
 		} catch (final Exception e) {
-			Log.w(TAG, "An exception occurred while creating bond", e);
+			loge("An exception occurred while creating bond", e);
 		}
 		return false;
 	}
@@ -692,6 +692,7 @@ import no.nordicsemi.android.dfu.internal.scanner.BootloaderScannerFactory;
 			mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_DEBUG, "gatt.getDevice().removeBond() (hidden)");
 			//noinspection ConstantConditions
 			result = (Boolean) removeBond.invoke(device);
+			logw("Bond information " + (result ? "removed" : "NOT removed"));
 
             // We have to wait until device is unbounded
             try {
@@ -703,7 +704,7 @@ import no.nordicsemi.android.dfu.internal.scanner.BootloaderScannerFactory;
                 loge("Sleeping interrupted", e);
             }
 		} catch (final Exception e) {
-			Log.w(TAG, "An exception occurred while removing bond information", e);
+			loge("An exception occurred while removing bond information", e);
 		}
 		return result;
 	}

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -903,7 +903,7 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 					 * On bonded devices the Service Changed indication will be sent to
 					 * indicate that the services has changed.
 					 *
-					 * The code below will wait 1.6 seconds for the indication, or continue
+					 * The code below will wait 4 seconds for the indication, or continue
 					 * with service discovery immediately when the indication is received.
 					 * See "onServiceChanged" method below.
 					 *
@@ -914,13 +914,13 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 					 * but this seems not to cause any issues.
 					 */
 					if (gatt.getDevice().getBondState() == BluetoothDevice.BOND_BONDED) {
-						logi("Waiting 1600 ms for a possible Service Changed indication...");
+						logi("Waiting 4000 ms for a possible Service Changed indication...");
 						mHandler.postDelayed(() -> {
 							if (mConnectionState != STATE_CONNECTING)
 								return;
 							mConnectionState = STATE_CONNECTED;
 							discoverServices(gatt);
-						}, 1600);
+						}, 4000);
 					} else {
 						mConnectionState = STATE_CONNECTED;
 						discoverServices(gatt);

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -829,7 +829,7 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 				sendLogBroadcast(LOG_LEVEL_WARNING, "Bluetooth adapter disabled");
 				mConnectionState = STATE_DISCONNECTED;
 				if (mDfuServiceImpl != null)
-					mDfuServiceImpl.getGattCallback().onDisconnected();
+					mDfuServiceImpl.getGattCallback().onDisconnected(22 /* GATT CONN TERMINATE LOCAL HOST */);
 
 				// Notify waiting thread
 				synchronized (mLock) {
@@ -930,7 +930,7 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 					logi("Disconnected from GATT server");
 					mConnectionState = STATE_DISCONNECTED;
 					if (mDfuServiceImpl != null)
-						mDfuServiceImpl.getGattCallback().onDisconnected();
+						mDfuServiceImpl.getGattCallback().onDisconnected(0);
 				}
 			} else {
 				if (status == 0x08 /* GATT CONN TIMEOUT */ || status == 0x13 /* GATT CONN TERMINATE PEER USER */)
@@ -941,7 +941,7 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 				if (newState == BluetoothGatt.STATE_DISCONNECTED) {
 					mConnectionState = STATE_DISCONNECTED;
 					if (mDfuServiceImpl != null)
-						mDfuServiceImpl.getGattCallback().onDisconnected();
+						mDfuServiceImpl.getGattCallback().onDisconnected(mError);
 				}
 			}
 
@@ -1482,7 +1482,7 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 						startService(newIntent);
 					return;
 				}
-				report(ERROR_DEVICE_DISCONNECTED);
+				report(e.getErrorNumber());
 			} catch (final DfuException e) {
 				int error = e.getErrorNumber();
 				// Connection state errors and other Bluetooth GATT callbacks share the same error numbers. Therefore we are using bit masks to identify the type.

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -906,6 +906,12 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 					 * The code below will wait 1.6 seconds for the indication, or continue
 					 * with service discovery immediately when the indication is received.
 					 * See "onServiceChanged" method below.
+					 *
+					 * It was tested using Pixel 7 with Android 15 using SDK 11 and 17.1, that
+					 * at least around 4 seconds are required. When service discovery is started
+					 * before SC indication is received, following operations will fail.
+					 * On SDK 11 the SC indication is received after service discovery is started,
+					 * but this seems not to cause any issues.
 					 */
 					if (gatt.getDevice().getBondState() == BluetoothDevice.BOND_BONDED) {
 						logi("Waiting 1600 ms for a possible Service Changed indication...");

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -967,6 +967,13 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 			}
 		}
 
+		// Note: This method was added in Android 11. Earlier versions will handle service change
+		//       internally, but will not notify the app, so the app will always wait for 4 seconds
+		//       before starting service discovery.
+		// Added here:
+		// https://cs.android.com/android/_/android/platform/packages/modules/Bluetooth/+/d173ec435715533f4c9fd3d104df70afae8826d8
+		// Exposed here:
+		// https://cs.android.com/android/_/android/platform/packages/modules/Bluetooth/+/f36b9b5d686e8bf02a1d9fd482324037ebf2310f
 		@Override
 		public void onServiceChanged(@NonNull final BluetoothGatt gatt) {
 			if (mConnectionState != STATE_CONNECTING)

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -1954,12 +1954,12 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 		updateForegroundNotification(builder);
 
 		try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                startForeground(NOTIFICATION_ID, builder.build(), ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE);
-            } else {
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+				startForeground(NOTIFICATION_ID, builder.build(), ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE);
+			} else {
 				startForeground(NOTIFICATION_ID, builder.build());
 			}
-        } catch (final SecurityException e) {
+		} catch (final SecurityException e) {
 			loge("Service cannot be started in foreground", e);
 			logi("Starting DFU service in background instead");
 		}

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuCallback.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuCallback.java
@@ -27,7 +27,7 @@ import android.bluetooth.BluetoothGattCallback;
 /* package */ interface DfuCallback extends DfuController {
 
 	class DfuGattCallback extends BluetoothGattCallback {
-		public void onDisconnected() {
+		public void onDisconnected(int error) {
 			// empty initial implementation
 		}
 	}

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyButtonlessDfuImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyButtonlessDfuImpl.java
@@ -207,7 +207,7 @@ import no.nordicsemi.android.dfu.internal.exception.UploadAbortedException;
 							@Nullable final BluetoothGattCharacteristic characteristic)
             throws DeviceDisconnectedException, DfuException, UploadAbortedException {
 		if (!mConnected)
-			throw new DeviceDisconnectedException("Unable to read version number: device disconnected");
+			throw new DeviceDisconnectedException("Unable to read version number: device disconnected", mError);
 		if (mAborted)
 			throw new UploadAbortedException();
 		// If the DFU Version characteristic is not available we return 0.
@@ -234,7 +234,7 @@ import no.nordicsemi.android.dfu.internal.exception.UploadAbortedException;
 			loge("Sleeping interrupted", e);
 		}
 		if (!mConnected)
-			throw new DeviceDisconnectedException("Unable to read version number: device disconnected");
+			throw new DeviceDisconnectedException("Unable to read version number: device disconnected", mError);
 		if (mError != 0)
 			throw new DfuException("Unable to read version number", mError);
 

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyDfuImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyDfuImpl.java
@@ -494,6 +494,10 @@ import no.nordicsemi.android.error.LegacyDfuError;
 			status = getStatusCode(response, OP_CODE_RECEIVE_FIRMWARE_IMAGE_KEY);
 			logi("Response received (Op Code = " + response[0] + ", Req Op Code = " + response[1] + ", Status = " + response[2] + ")");
 			mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_APPLICATION, "Response received (Op Code = " + response[1] + ", Status = " + status + ")");
+			if (status == 6 && numberOfPacketsBeforeNotification == 0 || numberOfPacketsBeforeNotification > 10) {
+				logw("Hint: Error 6 (OPERATION FAILED) means the date were sent too fast for the target to handle. " +
+						"Reduce the number of packets before notification (PRN) to 10 or less.");
+			}
 			if (status != DFU_STATUS_SUCCESS)
 				throw new RemoteDfuException("Device returned error after sending file", status);
 

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyDfuImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyDfuImpl.java
@@ -111,7 +111,8 @@ import no.nordicsemi.android.error.LegacyDfuError;
 				handlePacketReceiptNotification(gatt, characteristic, value);
 			} else  {
 				/*
-				 * If the DFU target device is in invalid state (f.e. the Init Packet is required but has not been selected), the target will send DFU_STATUS_INVALID_STATE error
+				 * If the DFU target device is in invalid state (e.g. the Init Packet is required
+				 * but has not been selected), the target will send DFU_STATUS_INVALID_STATE error
 				 * for each firmware packet that was send. We are interested may ignore all but the first one.
 				 * After obtaining a remote DFU error the OP_CODE_RESET_KEY will be sent.
 				 */

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyDfuImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyDfuImpl.java
@@ -393,6 +393,18 @@ import no.nordicsemi.android.error.LegacyDfuError;
 				}
 			}
 
+			// Request short connection interval.
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+				logi("Requesting high connection priority");
+				mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_VERBOSE,
+						"Requesting high connection priority...");
+				mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_DEBUG,
+						"gatt.requestConnectionPriority(HIGH)");
+				mGatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_HIGH);
+				// There will be a (hidden) callback on newer Android versions,
+				// but we don't have to wait for it.
+			}
+
 			/*
 			 * If the DFU Version characteristic is present and the version returned from it is greater or equal to 0.5, the Extended Init Packet is required.
 			 * For older versions, or if the DFU Version characteristic is not present (pre SDK 7.0.0), the Init Packet (which could have contained only the firmware CRC) was optional.

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyDfuImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/LegacyDfuImpl.java
@@ -682,7 +682,7 @@ import no.nordicsemi.android.error.LegacyDfuError;
 		if (mAborted)
 			throw new UploadAbortedException();
 		if (!mConnected)
-			throw new DeviceDisconnectedException("Unable to write Image Size: device disconnected");
+			throw new DeviceDisconnectedException("Unable to write Image Size: device disconnected", mError);
 		if (mError != 0)
 			throw new DfuException("Unable to write Image Size", mError);
 	}
@@ -743,7 +743,7 @@ import no.nordicsemi.android.error.LegacyDfuError;
 		if (mAborted)
 			throw new UploadAbortedException();
 		if (!mConnected)
-			throw new DeviceDisconnectedException("Unable to write Image Sizes: device disconnected");
+			throw new DeviceDisconnectedException("Unable to write Image Sizes: device disconnected", mError);
 		if (mError != 0)
 			throw new DfuException("Unable to write Image Sizes", mError);
 	}

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/SecureDfuImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/SecureDfuImpl.java
@@ -800,7 +800,7 @@ class SecureDfuImpl extends BaseCustomDfuImpl {
 			throws DfuException, DeviceDisconnectedException, UploadAbortedException,
 			UnknownResponseException, RemoteDfuException {
 		if (!mConnected)
-			throw new DeviceDisconnectedException("Unable to read Checksum: device disconnected");
+			throw new DeviceDisconnectedException("Unable to read Checksum: device disconnected", mError);
 
 		// Send the number of packets of firmware before receiving a receipt notification
 		logi("Sending the number of packets before notifications (Op Code = 2, Value = " + number + ")");
@@ -848,7 +848,7 @@ class SecureDfuImpl extends BaseCustomDfuImpl {
 			throws DeviceDisconnectedException, DfuException, UploadAbortedException, RemoteDfuException,
 			UnknownResponseException {
 		if (!mConnected)
-			throw new DeviceDisconnectedException("Unable to create object: device disconnected");
+			throw new DeviceDisconnectedException("Unable to create object: device disconnected", mError);
 
 		final byte[] data = (type == OBJECT_COMMAND) ? OP_CODE_CREATE_COMMAND : OP_CODE_CREATE_DATA;
 		setObjectSize(data, size);
@@ -877,7 +877,7 @@ class SecureDfuImpl extends BaseCustomDfuImpl {
 			throws DeviceDisconnectedException, DfuException, UploadAbortedException,
 			RemoteDfuException, UnknownResponseException {
 		if (!mConnected)
-			throw new DeviceDisconnectedException("Unable to read object info: device disconnected");
+			throw new DeviceDisconnectedException("Unable to read object info: device disconnected", mError);
 
 		OP_CODE_SELECT_OBJECT[1] = (byte) type;
 		writeOpCode(mControlPointCharacteristic, OP_CODE_SELECT_OBJECT);
@@ -910,7 +910,7 @@ class SecureDfuImpl extends BaseCustomDfuImpl {
 	private ObjectChecksum readChecksum() throws DeviceDisconnectedException, DfuException,
             UploadAbortedException, RemoteDfuException, UnknownResponseException {
 		if (!mConnected)
-			throw new DeviceDisconnectedException("Unable to read Checksum: device disconnected");
+			throw new DeviceDisconnectedException("Unable to read Checksum: device disconnected", mError);
 
 		writeOpCode(mControlPointCharacteristic, OP_CODE_CALCULATE_CHECKSUM);
 
@@ -948,7 +948,7 @@ class SecureDfuImpl extends BaseCustomDfuImpl {
 	private void writeExecute() throws DfuException, DeviceDisconnectedException,
             UploadAbortedException, UnknownResponseException, RemoteDfuException {
 		if (!mConnected)
-			throw new DeviceDisconnectedException("Unable to read Checksum: device disconnected");
+			throw new DeviceDisconnectedException("Unable to execute: device disconnected", mError);
 
 		writeOpCode(mControlPointCharacteristic, OP_CODE_EXECUTE);
 

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/SecureDfuImpl.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/SecureDfuImpl.java
@@ -236,7 +236,7 @@ class SecureDfuImpl extends BaseCustomDfuImpl {
 				mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_VERBOSE,
 						"Requesting high connection priority...");
 				mService.sendLogBroadcast(DfuBaseService.LOG_LEVEL_DEBUG,
-						"gatt.requestConnectionPriority(CONNECTION_PRIORITY_HIGH)");
+						"gatt.requestConnectionPriority(HIGH)");
 				mGatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_HIGH);
 				// There will be a (hidden) callback on newer Android versions,
 				// but we don't have to wait for it.

--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/internal/exception/DeviceDisconnectedException.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/internal/exception/DeviceDisconnectedException.java
@@ -22,13 +22,28 @@
 
 package no.nordicsemi.android.dfu.internal.exception;
 
+import no.nordicsemi.android.dfu.DfuBaseService;
+
 /**
  * Device has disconnected.
  */
 public class DeviceDisconnectedException extends Exception {
 	private static final long serialVersionUID = -6901728550661937942L;
 
-	public DeviceDisconnectedException(final String message) {
+	private final int mError;
+
+	public DeviceDisconnectedException(final String message, final int state) {
 		super(message);
+
+		mError = state;
+	}
+
+	public int getErrorNumber() {
+		return mError;
+	}
+
+	@Override
+	public String getMessage() {
+		return super.getMessage() + " (error " + (mError & ~DfuBaseService.ERROR_CONNECTION_STATE_MASK) + ")";
 	}
 }


### PR DESCRIPTION
This PR adds several improvements to the DFU library:
1. Logging issues fixed
2. [Legacy DFU] Requesting HIGH connection priority in Legacy DFU (see #466, which did the same for Secure DFU)
3. [Bonded devices]: Expected time to receive a Service Change indication and complete service discovery increased 1.6 -> 4 seconds.
4. Printing hints in the logs when on common error
5. Returning disconnection error on disconnection, instead of just "device disconnected".