### PR TITLE
Reference Capacitor implementation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,11 @@ iOS version of the same library can be found at [IOS-DFU-Library](https://github
 A library for both iOS and Android that is based on this library is available for React Native: 
 [react-native-nordic-dfu](https://github.com/Salt-PepperEngineering/react-native-nordic-dfu) 
 
+### Capacitor
+
+A library for both iOS and Android that is based on this library is available for [Capacitor](https://capacitorjs.com): 
+[nordic-dfu](https://github.com/robsonos/nordic-dfu)
+
 ### Flutter
 
 A library for both iOS and Android that is based on this library is available for Flutter: 


### PR DESCRIPTION
Hi maintainer,

This PR is to request adding the CapacitorJS implementation to README.

Kind regards,

Robson