### PR TITLE
Add Expo library to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,10 @@ iOS version of the same library can be found at [IOS-DFU-Library](https://github
 A library for both iOS and Android that is based on this library is available for React Native: 
 [react-native-nordic-dfu](https://github.com/Salt-PepperEngineering/react-native-nordic-dfu)
 
+### Expo
+
+An unofficial Expo module for both iOS and Android that is based on this library is available: [expo-nordic-dfu](https://github.com/getquip/expo-nordic-dfu)
+
 ### Capacitor
 
 A library for both iOS and Android that is based on this library is available for [Capacitor](https://capacitorjs.com):


### PR DESCRIPTION
We've started a new expo-module Nordic DFU library. It's modern - works with Expo SDK 52+, React Native Bridgeless, the iOS and Android files have been converted to Swift and Kotlin, and it has an Expo example app. Please give it a look and add the link if you deem it worthy!

https://github.com/getquip/expo-nordic-dfu