### PR TITLE
Common Nordic lib updated

### DIFF
--- a/gradle/nordic.versions.toml
+++ b/gradle/nordic.versions.toml
@@ -5,7 +5,7 @@
 
 [versions]
 blek = "2.0.0-alpha09"
-common = "2.6.0"
+common = "2.6.1"
 
 [libraries]
 # Native Android client for Bluetooth LE.


### PR DESCRIPTION
Version [2.6.1](https://github.com/NordicPlayground/Android-Common-Libraries/releases/tag/2.6.1) contains a fix for Bluetooth LE scanner view for too long device names.