### PR TITLE
fix: connecting and disconnecting state issue

### DIFF
--- a/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -1661,6 +1661,8 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 		if (mConnectionState == STATE_DISCONNECTED)
 			return;
 
+        mConnectionState = STATE_DISCONNECTING;
+
 		sendLogBroadcast(LOG_LEVEL_VERBOSE, "Disconnecting...");
 		mProgressInfo.setProgress(PROGRESS_DISCONNECTING);
 


### PR DESCRIPTION
Due to mLastProgress defaulting to -1 (STATE_CONNECTING) and a chec `mLastProgress == progress`, the callback `onDeviceConnecting` is never called. By changing the default to -0 (STATE_DISCONNECTED), the update is passed through.

By adding `progress >= 0 && progress <= 100` to the check, we can keep track of the retries that have passed.

Lastly, `STATE_DISCONNECTING` was never set, so i've added this in the corresponding block.